### PR TITLE
Byt några skall till ska

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -10,7 +10,7 @@ Dessa administrationer har antagit rekommendationer om sinsemellan harmoniserade
 
 
 Sverige har antagit CEPT-rekommendationen T/R 61-02. Vid genomförandet av
-kompetensprov skall de i den rekommendationen angivna kraven särskilt beaktas.
+kompetensprov ska de i den rekommendationen angivna kraven särskilt beaktas.
 
 \begin{rev-omarbetas}
 

--- a/koncept/appendix-c.tex
+++ b/koncept/appendix-c.tex
@@ -308,7 +308,7 @@ drivsteget och ändå är förstärkningen 10 dB i båda fallen. Decibel är
 m.a.o. dimensionslöst
 
 Men om en av två jämförda effekterna alltid är densamma och väl
-definierad så medges nya möjligheter. Den effekt som skall
+definierad så medges nya möjligheter. Den effekt som ska
 kvantifieras kan nu ställas i förhållande till den kända
 referenseffekten. Med denna förutsättning kan även de absoluta
 effektnivåerna, t.ex. genom en sändare uttryckas i decibel. Detta
@@ -319,7 +319,7 @@ med en impedans av 50 Ω. För god anpassning väljs då koaxialkablarna
 mellan apparaterna med en karaktäristisk impedans av 50 Ω.
 
 \emph{Det har utbildats en praxis, att referensvärdet vid jämförelse
-  av signalnivåer i radiosystem skall vara en milliwatt (1 mW)
+  av signalnivåer i radiosystem ska vara en milliwatt (1 mW)
   utvecklad i en belastning med impedansen 50 Ω.}
 
 Signalnivåer över belastningen 50 Ω kan uttryckas i dB(m), där (m)

--- a/koncept/appendix-d.tex
+++ b/koncept/appendix-d.tex
@@ -44,7 +44,7 @@ föreningarna VERON (Nederländerna) och RSGB (Storbritannien) en annan
 S-skala över 30 MHz.  Vid konferensen 1981 i Brighton antogs förslaget
 som rekommendation.
 
-Mätningar skall i båda fallen göras med en kvasi-toppvärdesdetektor
+Mätningar ska i båda fallen göras med en kvasi-toppvärdesdetektor
 med en stigtid av 10 ms \(\pm\)0.2 ms och en falltid av 500 ms.
 
 \begin{table}[h]

--- a/koncept/appendix-e.tex
+++ b/koncept/appendix-e.tex
@@ -67,7 +67,7 @@ frekvens än bärvågen. I den låga änden av basbandet kan frekvensen närma s
 eller vara likström (0 Hz). I den höga änden beror frekvensen på det värde där
 information finns liksom att det finns underbärvågor eller andra speciella
 signaler inom basbandet. Det finns ett basband för alla typer av signaler, vare
-sig de är analoga eller digitala. Det skall också förstås, att termen basband är
+sig de är analoga eller digitala. Det ska också förstås, att termen basband är
 relaterad till den modulation som avses från fall till fall.
 
 Det kan finnas mer än ett basband i en komplett modulationsprocess. Till
@@ -148,7 +148,7 @@ Sändningklass anges med tre tecken där:\\
 \end{tabular}
 
 \emph{not. Utsändning där huvudbärvågen är direkt modulerad av en signal,
-	vilken är kodad i kvantiserad form (t.ex. pulskodmodulation) skall hänföras till
+	vilken är kodad i kvantiserad form (t.ex. pulskodmodulation) ska hänföras till
 	amplitud eller vinkelmodulation.}
 
 \subsubsection{Den modulerande signalens karaktär}
@@ -173,7 +173,7 @@ signalen växlar språngvis mellan vissa givna tillstånd, och på kanaler för
 analog information, där signalen kan variera kontinuerligt inom givna gränser.
 
 \emph{Att fastställa arten av huvudbärvågens modulation kan kräva viss
-	eftertanke. I många fall får den information som skall överföras, modulera en
+	eftertanke. I många fall får den information som ska överföras, modulera en
 	underbärvåg, som i sin tur påtrycks modulatorn för huvudbärvågen.}
 
 \subsubsection{Informationens form}

--- a/koncept/chapter1-10.tex
+++ b/koncept/chapter1-10.tex
@@ -181,7 +181,7 @@ användas för ett visst frekvensband för att konvertera ned detta band i
 processen, något som är väldigt populärt i SDR sammanhang. I bägge dessa fall
 är filtret ett \emph{anti-vikningsfilter} (eng. \emph{anti-aliasing filter}).
 
-Omvänt, när man skall konvertera från tids-diskret till tids-kontinuerlig
+Omvänt, när man ska konvertera från tids-diskret till tids-kontinuerlig
 signal så viker sig signalen uppåt i frekvens, och för att undertrycka dessa
 oönskade frekvenser används på samma sätt ett anti-vikningsfilter. På samma
 sätt som förut kan man antingen få de låga frekvenserna som för tal med ett

--- a/koncept/chapter1-4.tex
+++ b/koncept/chapter1-4.tex
@@ -232,7 +232,7 @@ kan hållas igång med tillförsel av yttre energi.
 
 Fält i rörelse alstrar elektromagnetisk strålning, som påverkar funktioner i
 omgivningen. När påverkan inte är önskvärd, måste fältet skärmas av. Ett sätt
-att skärma magnetiska fält är en metallisk kapsling. Kapslingen skall vara tät
-och bilda en sluten magnetisk krets. Kapslingen skall vara utförd i ett
+att skärma magnetiska fält är en metallisk kapsling. Kapslingen ska vara tät
+och bilda en sluten magnetisk krets. Kapslingen ska vara utförd i ett
 material som är en god ledare av magnetiskt flöde.
 (Jämför \ref{elektrostatik skärmning})

--- a/koncept/chapter1-5.tex
+++ b/koncept/chapter1-5.tex
@@ -203,7 +203,7 @@ Amatörradio tilldelas ett antal frekvensområden i intervallet 1,8 MHz till
 250 GHz.
 
 Att märka är att elektromagnetiska fält, som sagts ovan, förekommer så långt
-ner i frekvens som ett fåtal kHz. Detta skall självklart inte förväxlas med
+ner i frekvens som ett fåtal kHz. Detta ska självklart inte förväxlas med
 ljudtryck med samma frekvens.
 
 \subsubsection{Egenskaper hos elektromagnetiska vågor}

--- a/koncept/chapter1-6.tex
+++ b/koncept/chapter1-6.tex
@@ -103,7 +103,7 @@ pendelrörelse eller ett helt varv vid rotation.
 \index{periodtid (T)}
 \index{symbol!\(T\) periodtid}
 
-Periotid \(T\) är den tid som åtgår för att strömmen eller spänningen skall
+Periotid \(T\) är den tid som åtgår för att strömmen eller spänningen ska
 genomlöpa en period. Periodtiden är det inverterade värdet av frekvensen.
 
 Måttenheten för periodtid är sekund [s].

--- a/koncept/chapter1-7.tex
+++ b/koncept/chapter1-7.tex
@@ -117,7 +117,7 @@ Bilden visar ett avsnitt av en AM-mottagare. Från vänster hämtas en
 AM-modulerad signal från MF-förstärkaren för att demoduleras, d.v.s. för att
 återvinna den modulerande LF-signalen. MF-signalen halvvågslikriktas. Kvar blir
 den positiva delen av MF-signalen och den modulerande LF-signalen,
-sammanlagrade. LF-signalen skall nu skiljas ut och förstärkas. Alltså filtreras
+sammanlagrade. LF-signalen ska nu skiljas ut och förstärkas. Alltså filtreras
 MF-komposanten bort. Kvar blir LF-signalen, men överlagrad på en likspänning.
 Likspänningen stoppas och kvar blir slutligen LF-signalen som förstärks.
 

--- a/koncept/chapter1-8.tex
+++ b/koncept/chapter1-8.tex
@@ -85,7 +85,7 @@ de frekvensband som är tilldelade för amatörradioanvändning, men även för 
 kunna umgås med annan trafik inom banden.
 
 I alla sändningsslag ökar den använda bandbredden med ökad modulation. Eftersom
-största \emph{frekvenseffektivitet} alltid skall eftersträvas så upptar en
+största \emph{frekvenseffektivitet} alltid ska eftersträvas så upptar en
 sändare med kraftigare modulation än vad som behövs för en överföring, alltid
 onödigt frekvensutrymme.
 
@@ -574,7 +574,7 @@ Där är \(\Delta f_{max} = 75 kHz\) och \(f_{LFmax} =15 kHz\), därmed är
 \(m = \frac{75}{15} = 5\) och \(b = 2 \cdot (75 + 15) = 180 kHz\).
 
 Som framgår av tabellen på nästa uppslag varierar bärvågens liksom
-sidofrekvensernas inbördes amplitud med modulationsindex. Detta skall jämföras
+sidofrekvensernas inbördes amplitud med modulationsindex. Detta ska jämföras
 med AM där bärvågens amplitud är konstant och endast sidbandens amplitud
 varierar.
 
@@ -951,7 +951,7 @@ dvs. man klarar av att överföra upp till 10 miljoner bitar per sekund.
 Det är ofta som man pratar om den råa överföringskapaciteten, medans den
 verkliga överföringskapaciteten för nytto-trafik är något lägre på grund av
 olika former av packningsformat och protokoll-behov, så kallad \emph{overhead}.
-Man skall därför vara noga med att skilja dessa åt.
+Man ska därför vara noga med att skilja dessa åt.
 
 \end{rev-nytt}
 
@@ -1019,7 +1019,7 @@ störningar och hur dessa störningar påverkar vårt överförda data. Precis s
 vår CW eller SSB kan vara störd av atmosfäriska störningar, andra sändare
 eller helt enkelt vara svaga signaler så att det interna bruset blir en
 begränsning, så kommer mottagningen av digitala signaler att bli störd.
-Vi skall titta på dessa grundläggande begrepp som bitfel, bitfelssannolikhet,
+Vi ska titta på dessa grundläggande begrepp som bitfel, bitfelssannolikhet,
 felupptäckt samt korrigering med återsändning eller korrigeringskoder.
 
 \end{rev-nytt}
@@ -1041,7 +1041,7 @@ Q är större än 0 och mindre än 2 så är symbol 5 den enda vettiga symbolen,
 det är precis den tolkning vi i allmänhet gör, för det är den symbolen vars
 avstånd är lägst och därmed rimligast. Det kan dock vara så att man egentligen
 sände symbol 9 med -1 i I och +1 i Q, och därmed fått för stor störning på I
-för att man skall tolka det som rätt symbol. Vi kommer då lägga ut 9 istället
+för att man ska tolka det som rätt symbol. Vi kommer då lägga ut 9 istället
 för 5, vilket innebär att två bitar har ändrats.
 
 Genom att granska tabell \ref{tab:QAM-16} vidare så ser man att värdena för

--- a/koncept/chapter1-9.tex
+++ b/koncept/chapter1-9.tex
@@ -68,7 +68,7 @@ förstärkningen är således 0 Bel. En tiondel därav är 0 decibel (0 dB).
 
 Omräkning av kvoten av en effektändring till dB görs så, att 10-logaritmen för
 kvoten söks och resultatet blir effektändringen uttryckt i Bel (B). Om
-resultatet uttrycks i dB, skall Bel-värdet multipliceras med 10.
+resultatet uttrycks i dB, ska Bel-värdet multipliceras med 10.
 
 Logaritmer förklaras i appendix \ref{logaritmer}.
 

--- a/koncept/chapter10-1.tex
+++ b/koncept/chapter10-1.tex
@@ -29,7 +29,7 @@ går genom kroppen.
 \index{hjärt- och lungräddning (HLR)}
 \index{HLR}
 
-Vid hjärtstillestånd, hjärtkammarflimmer eller andningsstillestånd skall
+Vid hjärtstillestånd, hjärtkammarflimmer eller andningsstillestånd ska
 hjärt- och lungräddning påbörjas omedelbart då obotliga hjärnskador av
 syrebrist kan uppstå inom några få minuter. Finns en hjärtstartare,
 AED, i närheten bör den användas så skyndsamt som möjligt.
@@ -112,7 +112,7 @@ elektronikutrustningar. Halvledare är särskilt känsliga för
 kraftfält. Det är möjligt att känsliga instrument, hjärtstimulatorer
 (pacemaker) etc. kan påverkas av högfrekventa elektromagnetiska
 fält från radiosändare. När du använder en sändare, mobiltelefon etc.
-och någon får svårigheter med hjärta eller andning så skall du
+och någon får svårigheter med hjärta eller andning så ska du
 omedelbart stänga av din apparat helt! Med tiden utvecklas
 störningsokänsligare elektronik, men säker mot störningar kan man
 aldrig vara.
@@ -121,7 +121,7 @@ aldrig vara.
 
 Det finns flera olika normer och rekommendationer för elektromagnetiska
 fältstyrkor. Några av dessa normer har till exempel syftet att olika slags
-apparater skall kunna samexistera och därför fungera utan att påverkas av
+apparater ska kunna samexistera och därför fungera utan att påverkas av
 elektromagnetiska fält eller stråla ut elektromagnetiska fält överstigande
 givna gränsvärden (EMC).
 

--- a/koncept/chapter10-2.tex
+++ b/koncept/chapter10-2.tex
@@ -46,7 +46,7 @@ högst 200VA och ström begränsad av säkring på högst 10A.
 \item Reparera och tillverka apparatkablar och skarvsladdar
 \end{itemize}
 
-\textbf{Kom ihåg, att auktoriserad installatör skall anlitas för arbete
+\textbf{Kom ihåg, att auktoriserad installatör ska anlitas för arbete
 i fasta installationer.}
 
 \subsection{Radioamatören och hembyggd elektronik}
@@ -139,16 +139,16 @@ gärna markera att den brytaren är tillslagen och att stationen är
 under spänning. Informera familjen och övriga i din omgivning om hur
 den brytaren fungerar. Det är en säkerhetsåtgärd om något skulle hända.
 
-Apparaternas nätströmbrytare skall vara utförda för den aktuella
+Apparaternas nätströmbrytare ska vara utförda för den aktuella
 arbetsspänningen och ha ett godkänt utförande.
 
-Vid 1-fassystem skall nätströmbrytaren i apparaterna vara 2-polig och
+Vid 1-fassystem ska nätströmbrytaren i apparaterna vara 2-polig och
 bryta fas- och N-ledare, men aldrig PE-ledaren.
 
-Vid 3-fassystem skall nätströmbrytaren vara 3-polig och bryta fasledarna,
+Vid 3-fassystem ska nätströmbrytaren vara 3-polig och bryta fasledarna,
 men aldrig N-ledare och PE-ledare.
 
-\textbf{Kom ihåg, att auktoriserad installatör skall
+\textbf{Kom ihåg, att auktoriserad installatör ska
   anlitas vid ingrepp i fasta installationer.}
 
 \subsection{Liten terminologi vid elinstallationer}
@@ -159,7 +159,7 @@ men aldrig N-ledare och PE-ledare.
   ledningar till belysning, el-spisar, uttag m.m.
 \item[Fasledare] En ledare som för fasspänning.
 \item[Nolledare (N-ledare)] En ledare som är ansluten till elnätets
-  s.k.  nollpunkt (nollskena) och som normalt inte skall föra spänning
+  s.k.  nollpunkt (nollskena) och som normalt inte ska föra spänning
   till jord.
 \item[Skyddsledare (PE-ledare)] De ledare i kablar och sladdar, som är
   speciellt avsedda för skyddsjordning.
@@ -210,7 +210,7 @@ inte försetts medlamp- och vägguttag med jorddon.
 Vid nybyggnation är emellertid numera alla uttag är av skyddsjordat utförande!
 
 Det rekommenderas att installera skyddsjordade vägguttag för
-radiostationen. Observera då, att alla uttag i det rummet skall vara
+radiostationen. Observera då, att alla uttag i det rummet ska vara
 skyddsjordade!
 
 \subsection{Skyddsjordning}
@@ -261,7 +261,7 @@ anläggningar!
 
 Särjordning är ett uttryck för att jorda apparater till en separat
 jordpunkt, Det görs via separat jordlina till ett jordtag,
-d.v.s. jordplåt eller jordspett. Särjordning skall ske på rätt sätt
+d.v.s. jordplåt eller jordspett. Särjordning ska ske på rätt sätt
 eftersom det avsedda skyddet annars kan bli en fara.
 
 \emph{Om du har planer på särjordning, fråga en auktoriserad installatör.}
@@ -281,6 +281,6 @@ normalt används. Tröga säkringar för samma strömstyrka kan behövas för
 apparater som har speciellt hög startström, t.ex. stora
 nättransformatorer med toroidkärna.
 
-Säkringarna skall kunna bryta tillräcklig hög spänning, annars blir det
+Säkringarna ska kunna bryta tillräcklig hög spänning, annars blir det
 en kvarstående ljusbåge i dem vid säkringsbrott. Använd säkringar med rätta
 strömvärden. Det är förbjudet att laga säkringar då det kan orsaka brand.

--- a/koncept/chapter10-3.tex
+++ b/koncept/chapter10-3.tex
@@ -4,20 +4,20 @@
 
 Elektricitet kan lätt vålla både personskador och materiella
 skador. Det är viktigt att veta hur skador kan undvikas. Elektrisk
-utrustning skall vara beröringsskyddad med fullgod kapsling. Samtidigt
+utrustning ska vara beröringsskyddad med fullgod kapsling. Samtidigt
 får värmen inne i kapslingen inte bli så hög att det innebär
 brandrisk. Spontana fel kan trots allt uppstå.
 
 Isolationsfel medför risk vid beröring och brand kan utvecklas snabbt.
-När utrustning under spänning lämnas obevakad, skall det ske med särskild
+När utrustning under spänning lämnas obevakad, ska det ske med särskild
 aktsamhet.
 
 Hur elektriska apparater och anläggningar får utföras, regleras av
-lagar och föreskrifter. Elektriska apparater skall uppfylla vissa krav
-för att få marknadsföras och användas. Utförande och ursprung skall
+lagar och föreskrifter. Elektriska apparater ska uppfylla vissa krav
+för att få marknadsföras och användas. Utförande och ursprung ska
 vara dokumenterat på föreskrivet sätt.
 
-Även självbyggda apparater skall uppfylla kraven på elsäkerhet -
+Även självbyggda apparater ska uppfylla kraven på elsäkerhet -
 d.v.s. säkerhet mot elchock och brand - och byggaren bär ensam
 ansvaret för att utförandet och hanterandet av apparaterna är
 betryggande.
@@ -77,7 +77,7 @@ En obalanserad antenn kan resultera i stor spänning även på ansluten
 antenn-kabel, och kan därför innebära samma risker som att ta i själva
 antennen. T-antennen är en antenn som är designad för att utnyttja denna
 balans då själva antenn-kabeln är del av antennen utstrålande delar,
-medans de flesta andra antenner så skall antenn-kabeln inte stråla och
+medans de flesta andra antenner så ska antenn-kabeln inte stråla och
 ska därför inte innebära fara, men iakttag försiktighet. Obalans bör
 åtgärdas, inte enbart av personsäkerhet utan även för att få en effektiv
 antenn.
@@ -109,7 +109,7 @@ Kondensatorer kan behålla en betydande restladdning under många timmar
 sedan kraften brutits.
 \begin{itemize}
 \item Koppla urladdningsresistorer (bleeder) över filterkondensatorer,
-  så att de laddas ur när matningen stängs av. Av säkerhetsskäl skall
+  så att de laddas ur när matningen stängs av. Av säkerhetsskäl ska
   urladdningsresistorerna tåla fyra gånger så stor effekt som de
   själva förbrukar under drift.
 \item Varning: När du laddar ur en kondensator, kortslut den inte! Använd
@@ -125,13 +125,13 @@ Transformator med förstärkt säkerhet
   (fulltransformator) - helst av klass II (extraisolerad).
 \end{itemize}
 
-Vid reparation skall utrustningen vara spänningslös. Före arbetet skall du
+Vid reparation ska utrustningen vara spänningslös. Före arbetet ska du
 \begin{itemize}
 \item Stänga av utrustningens nätströmbrytare,
 \item Dra ur stickproppen ur vägguttaget (dubbel säkerhet),
 \end{itemize}
 
-Om trimning eller felsökning måste ske under spänning skall följande iakttas:
+Om trimning eller felsökning måste ske under spänning ska följande iakttas:
 \begin{itemize}
 \item Arbeta inte med anläggningen när du är trött eller
   omotiverad. Då är du minst vaksam mot olyckor.

--- a/koncept/chapter10-4.tex
+++ b/koncept/chapter10-4.tex
@@ -26,7 +26,7 @@ och människor. Observera, att man inte får ``haka på'' husets
 ordinarie åskledare. Då gäller inte husförsäkringen.
 
 Antennkabeln, som fungerar som en (för klent dimensionerad) åskledare,
-skall naturligtvis INTE I ONÖDAN dras in i huset utan kortaste vägen
+ska naturligtvis INTE I ONÖDAN dras in i huset utan kortaste vägen
 utanför huset till en avgrening.
 
 Från avgreningen fortsätter dels kabeln in till apparaterna genom ett

--- a/koncept/chapter11-1.tex
+++ b/koncept/chapter11-1.tex
@@ -32,12 +32,12 @@ Ibland behöver man göra förtydliganden genom att bokstavera.
 Det internationella finns i ITU radioreglemente (RR) \cite[Appendix 14]{ITU-RR}
 och kravställs i CEPT för HAREC \cite[Annex 6]{TR6102}.
 
-Svenska radioamatörer skall kunna två fonetiska alfabeten, dels det
+Svenska radioamatörer ska kunna två fonetiska alfabeten, dels det
 internationella och dels det svenska.
 
 Det kan vara värt att veta att det förekommer slang med andra ord vid
 bokstavering. Det finns därtill bokstavering på flera språk. Medans
-dessa inte skall användas vid internationell trafik, så kan det vara bra
+dessa inte ska användas vid internationell trafik, så kan det vara bra
 att känna till. \url{https://en.wikipedia.org/wiki/NATO_phonetic_alphabet}
 
 \begin{table}[htbp]

--- a/koncept/chapter11-2.tex
+++ b/koncept/chapter11-2.tex
@@ -231,15 +231,15 @@ Användning an Q-koder för maritimt bruk enligt ITU-R M.1172
 	anropssignaler, frekvenser, tidsuppgifter, person- och ortsnamn,
 	siffror, nummer o.s.v. I den beskrivande texten för vissa Q-koder
 	lämnas inom en parentes plats för ytterligare uppgifter. Dessa
-	uppgifter skall då sändas i den ordning som anges i texten.
+	uppgifter ska då sändas i den ordning som anges i texten.
 	\item Q-koderna antar formen av fråga, då de vid radiotelegrafering
 	åtföljs av frågetecken liksom då de vid radiotelefonering åtföljs av
 	bokstäverna RQ (ROMEO QUEBEC). När kompletterande uppgifter följer
-	efter en uttalad fråga, skall ett frågetecken respektive RQ följa
+	efter en uttalad fråga, ska ett frågetecken respektive RQ följa
 	efter uppgifterna.
-	\item Q-koder med numrerade alternativa betydelser skall åtföljas av
-	motsvarande siffra. Siffran skall sändas omedelbart efter
+	\item Q-koder med numrerade alternativa betydelser ska åtföljas av
+	motsvarande siffra. Siffran ska sändas omedelbart efter
 	förkortningen.
-	\item I internationell radiotrafik skall, då ej annat anges,
+	\item I internationell radiotrafik ska, då ej annat anges,
 	tidpunkter anges i Universal Time Coordinate (UTC) tidigare (GMT).
 \end{enumerate}

--- a/koncept/chapter11-5.tex
+++ b/koncept/chapter11-5.tex
@@ -2,7 +2,7 @@
 
 \subsection{Anropssignalernas syfte}
 
-Alla radiosändare skall vara identifierbara, så att man kan identifiera vem
+Alla radiosändare ska vara identifierbara, så att man kan identifiera vem
 som sänder \cite[§19.1]{ITU-RR}. Detta görs genom att skicka en
 identifikationssignal. Denna identifikationssignal är internationellt
 koordinerad och unik, vilket är nödvändigt när signalerna kan komma att
@@ -12,7 +12,7 @@ amatörradio.
 
 Alla sändningar med falsk eller missledande identifiering är förbjuden \cite[§19.2]{ITU-RR}!
 
-Alla amatör-radiosändningar skall vara identifierade \cite[§19.4, §19.5]{ITU-RR}.
+Alla amatör-radiosändningar ska vara identifierade \cite[§19.4, §19.5]{ITU-RR}.
 
 Identifiering sker normalt i tal eller Morse, men även andra former kan
 förekomma som är anpassad till modulationsmetoden som används.
@@ -40,7 +40,7 @@ HAREC b.\ref{HAREC.b.5.1}\label{myHAREC.b.5.1},
  b.\ref{HAREC.b.5.3}\label{myHAREC.b.5.3}
 }
 
-En radiostation skall identifieras med den anropssignal, som
+En radiostation ska identifieras med den anropssignal, som
 tilldelats av det egna landets teleadministration (myndighet). I Sverige
 är det Post- och telestyrelsen (PTS) som har ansvaret och genom
 delegationsbeslut delegerat handläggningen amatörradiosignaler till föreningen Sveriges SändareAmatörer (SSA).
@@ -50,10 +50,10 @@ Anropssignalen meddelas i det radioamatörcertifikat som erhålls efter godkänt
 Amatörradiosignaler är uppbyggda på följande sätt \cite[§19.68, §19.69]{ITU-RR}:
 
 Ett tecken (ett av B, F, G, I, K, M, N, R eller W) och en siffra, följt av en
-grupp av inte mer än 4 tecken, varav sista skall vara en bokstav.
+grupp av inte mer än 4 tecken, varav sista ska vara en bokstav.
 
 Två tecken och en siffra, följt av en grupp av inte mer än 4 tecken, varav
-sista skall vara en bokstav.
+sista ska vara en bokstav.
 
 Till bokstav räknas A-Z och till siffra räknas 0-9 \cite[§19.45]{ITU-RR}.
 Ett tecken är antingen en bokstav eller siffra.
@@ -170,7 +170,7 @@ tillägg till signalen.
 \textbf{Exempel:} SK7AX är en amatörklubb hemmahörande i Jönköping län.
 
 I Post- och telestyrelsens föreskrifter sägs dock inte vilken
-distriktssiffra som skall användas, när sändning sker från annan plats
+distriktssiffra som ska användas, när sändning sker från annan plats
 än hemortsadressen.
 
 Med stöd av praxis rekommenderar dock SSA att följande regler
@@ -205,7 +205,7 @@ tillämpas:
   bestämmelser.  Vid osäkerhet- Skaffa upplysningar från SSA:s
   reciprokfunktionär!
 
-\item Utländsk radioamatör på besök i Sverige skall använda sin
+\item Utländsk radioamatör på besök i Sverige ska använda sin
   anropssignal från det egna landet, föregånget av SM*/ där *
   motsvaras av siffran för det svenska distrikt varifrån sändningen
   görs. \textbf{Exempel:} SM5/LA8PV.
@@ -216,10 +216,10 @@ tillämpas:
 HAREC b.\ref{HAREC.b.5.2}\label{myHAREC.b.5.2}
 }
 
-Både motstationens och den egna anropssignalen skall användas i början
-och slutet av varje sändning.  Under sändningen skall anropssignalen
+Både motstationens och den egna anropssignalen ska användas i början
+och slutet av varje sändning.  Under sändningen ska anropssignalen
 upprepas ``med korta mellanrum'', utan närmare precisering av
-mellanrummet.  Även om man inte har kontakt med en motstation, skall
+mellanrummet.  Även om man inte har kontakt med en motstation, ska
 den egna anropssignalen anges vid varje sändning.  Se vidare i PTS
 föreskrifter.
 

--- a/koncept/chapter11-6.tex
+++ b/koncept/chapter11-6.tex
@@ -26,7 +26,7 @@ administrationerna, och därmed gäller det inte per automatik över
 nationell lag, utan man behöver alltid hålla sig bekant med vad gällande lag
 och föreskrifter säger.
 
-För att radioamatörer sedan skall använda banden på ett liknande sätt, så har
+För att radioamatörer sedan ska använda banden på ett liknande sätt, så har
 sedan IARU skrivit ihop en bandplan, som enbart kan tolkas som en
 rekommendation inom den ram som nationella lagar och föreskrifter sätter på
 radiosändning.
@@ -67,7 +67,7 @@ amatöraktiviteter som möjligt, såväl sändningsslag som tekniker, både nu o
 framtiden. För att utnyttja banden på bästa sätt är det normalt att minsta
 möjliga bandbredd samt optimal sändarutrustning och teknik används.
 
-För att alla skall kunna utöva amatörradio med ett minimum av störningar,
+För att alla ska kunna utöva amatörradio med ett minimum av störningar,
 förutsätts att man använder utrustningar som är ``state of the art''.  God
 insikt i frekvensplanering, tillräckliga resurser, gott anseende samt
 internationellt samarbete behövs för att främja amatörradion. De flesta

--- a/koncept/chapter12-1.tex
+++ b/koncept/chapter12-1.tex
@@ -4,12 +4,12 @@
   kontakten respekteras.}
 
 \emph{En hel serie både internationella och nationella regler styr
-  radiokommunikationerna i en nation. Varje radioamatör skall känna
+  radiokommunikationerna i en nation. Varje radioamatör ska känna
   till och följa dessa regler så långt de har anslutning till
   amatörradio. Vissa länder - t.ex. CEPT-länderna - har i någon
   utsträckning harmoniserat sina bestämmelser inbördes.  Nationella
   avvikelser förekommer likväl och reglerna i det land, som man gör
-  radiosändningar ifrån, skall alltid följas.}
+  radiosändningar ifrån, ska alltid följas.}
 
 \section{ITU Radioreglemente (RR)}
 \index{Internationella TeleUnionen (ITU)}
@@ -30,7 +30,7 @@ verksamhet. Det är det gemensamma ramverk som används, och där sedan varje la
 utgår från det för att sedan skriva de nationella föreskrifterna och
 tilldelningarna. Dock, den ansvariga myndigheten behöver inte följa ITU RR
 strikt, och det förekommer flera fall där saker i ITU RR ser tillåtna ut men
-de nationella föreskrifterna sedan inte tillåter det. Man skall därför inte
+de nationella föreskrifterna sedan inte tillåter det. Man ska därför inte
 tolka ITU RR som det som gäller istället för de nationella föreskrifterna utan
 snarare en utgångspunkt. Det kan ha skett förändringar i ITU RR men där
 existerande frekvensallokeringar nationellt förhindrar att följa ITU RR.

--- a/koncept/chapter12-3.tex
+++ b/koncept/chapter12-3.tex
@@ -18,7 +18,7 @@ tillståndsplikt.
 
 \emph{Post- och telestyrelsen - PTS} - är enligt Förordning (2003:396) om
 elektronisk kommunikation den svenska myndighet (administration) som handlägger
-ärenden gällande telekommunikation. PTS skall bland annat svara för att
+ärenden gällande telekommunikation. PTS ska bland annat svara för att
 möjligheterna till radiokommunikationer utnyttjas effektivt och har därvid att
 beakta den internationella regleringen inom området. Regleringen av
 amatörradioanvändningen begränsas nu till den minsta omfattning som

--- a/koncept/chapter14-1.tex
+++ b/koncept/chapter14-1.tex
@@ -66,8 +66,8 @@ lika gärna lägga sin jordanslutning ned i en blomkruka för där gör den lika
 god nytta.
 
 Inom elkraft förekommer även termen \emph{nolla} (eng. \emph{neutral}), den
-kan lätt förväxlas med jorden, men skall hanteras separat från skyddsjord utom
-där elsäkerhetsföreskrifter föreskriver att de skall vara sammankopplade.
+kan lätt förväxlas med jorden, men ska hanteras separat från skyddsjord utom
+där elsäkerhetsföreskrifter föreskriver att de ska vara sammankopplade.
 Nollan är den ledare som är retur-ledare för strömmen. Nollan är sammankopplad
 med skyddsjorden i elcentralen, men sedan hanteras den som en separat ledare.
 Man får inte koppla ihop dem för att spara ledare!
@@ -218,7 +218,7 @@ Det här scenariot liknar t.ex. det hos en normal hemmastereo och ändå kan det
 uppstå \emph{jordbrum} i denna koppling. Det finns flera skäl. Ett skäl är att
 transformatorer visserligen erbjuder en galvanisk isolation, men de är även
 kapacitiva spänningsdelare för den spänning som finns över primär-lindningen,
-med 230 VAC spänning så behövs bara lite läckage över för att man skall
+med 230 VAC spänning så behövs bara lite läckage över för att man ska
 uppleva att isolationen brister. Det brukar vara rekommendabelt att helt
 enkelt lasta denna spänningsdelare med ett motstånd, så att signaljord och
 skyddsjord sitter ihop med ett någorlunda högt motstånd, ofta med en
@@ -227,11 +227,11 @@ få för mycket störningar från den ström som kommer flyta mellan jordarna.
 
 Ett annat scenario som skapar jordbrum är när man i någon ände råkar hårt
 koppla samman signaljord och skyddsjord, typiskt att det blir oavsiktlig
-kontakt mot chassi, som skall vara skyddsjordad. Själva chassit brukar man
+kontakt mot chassi, som ska vara skyddsjordad. Själva chassit brukar man
 prata om som \emph{chassijordat}, men det är egentligen bara skyddsjord på de
 flesta system.
 
-För att isolationsjordning skall fungera måste alla kontakter vara isolerade
+För att isolationsjordning ska fungera måste alla kontakter vara isolerade
 från chassit, och även signaljord får inte ha kontakt med chassi inuti
 apparaten. Man behöver alltså försäkra sig om isolationsavstånd, vilket
 väldigt lätt kan missas av att man har en skruv som råkar skrapa sig igenom
@@ -296,7 +296,7 @@ Man har inte heller problem med att man skulle råka jorda eller att man skulle
 tappa den enda jordvägen. Istället försöker man koppla ihop jordarna väl.
 
 Ett vanligt problem är om man låter jordströmmarna gå genom kretskort, vilket
-gör att man skapar lokala seriejordningsproblem. Man skall se till att
+gör att man skapar lokala seriejordningsproblem. Man ska se till att
 jordströmmarna knyter hårt till chassit, men svagt genom kortet för att på det
 sättet få bästa möjliga isolation. Denna princip är också lämplig för att
 kunna hantera t.ex. ESD skador.
@@ -540,7 +540,7 @@ I en transformator med mitt-tapp kan mitt-tappen sitta lite förskjuten från
 riktiga mitten, så att anslutningen av mitt-tappen till jord skapar en
 obalans.
 
-Dessa exempel på imperfektion skall man vara medveten om, så att man inte
+Dessa exempel på imperfektion ska man vara medveten om, så att man inte
 tillskriver en transformator eller strömbalun en perfekt isolation av
-egenskaperna. Snarare skall man förvänta sig att den inte är perfekt och
+egenskaperna. Snarare ska man förvänta sig att den inte är perfekt och
 anpassa design efter det.

--- a/koncept/chapter2-1.tex
+++ b/koncept/chapter2-1.tex
@@ -12,8 +12,8 @@ För att få avsedd funktion, så anpassar man resistansen i komponenterna.
 \emph{Exempel}
 En krets med strömkälla, lampa, kopplingsledningar och smältsäkring.
 Kopplingsledningarna mellan komponenterna bör ha låg resistans och därför lågt
-spänningsfall (små förluster). Lampan skall däremot ha hög resistans och därmed
-höga förluster för att kunna bli het och lysa. Smältsäkringen skall skydda
+spänningsfall (små förluster). Lampan ska däremot ha hög resistans och därmed
+höga förluster för att kunna bli het och lysa. Smältsäkringen ska skydda
 ledningarna från för hög ström. Säkringen ges därför en resistans, som gör
 att den smälter när strömmen överstiger ett tillåtet värde.
 Som hjälpmedel för att fördela spänningar och strömmar i en krets, så används
@@ -286,7 +286,7 @@ potentiometer.
 
 I en potentiometer används dels hela resistansen mellan ändpunkterna och dels
 andelen mellan uttaget och någon av ändpunkterna. Uttagets mekaniska utförande
-beror oftast av hur bekvämt inställningen skall kunna ske. En potentiometer,
+beror oftast av hur bekvämt inställningen ska kunna ske. En potentiometer,
 där det resistiva materialet är lagt på en cirkulär bana och uttaget är fäst
 vid en axel i banans centrum, medger enkel inställning med mejsel, ratt etc.
 Ett enklare slags uttag är en släpkontakt eller ett spännband som kan flyttas

--- a/koncept/chapter2-10.tex
+++ b/koncept/chapter2-10.tex
@@ -110,8 +110,8 @@ slutsteg som arbetar i klass AB, B eller C.
 Bristande värmeavledning leder ofta till ett katastrofalt fel, som t.ex.
 sönderbrända motstånd och transistorer. Även ledare kan brinna av när man
 har för liten ledararea, och därmed för hög resistans, för den ström som
-skall gå genom den. Av det skälet finns det dimensioneringsregler t.ex.
-krav på minsta arean av koppar i ledare helt enkelt för att de inte skall
+ska gå genom den. Av det skälet finns det dimensioneringsregler t.ex.
+krav på minsta arean av koppar i ledare helt enkelt för att de inte ska
 skapa brand.
 
 En annan effekt av värmeledning är att det kan ibland vara svårt att löda

--- a/koncept/chapter2-3.tex
+++ b/koncept/chapter2-3.tex
@@ -224,7 +224,7 @@ I en ideal induktor är spänningen fasförskjuten 90° före strömmen. I prakt
 \textbf{HAREC a.\ref{HAREC.a.2.3.6}\label{myHAREC.a.2.3.6}}
 \index{Q-faktor!induktor}
 
-Q-faktorn kan avse två olika saker, som inte skall förväxlas. Det är Q-faktorn
+Q-faktorn kan avse två olika saker, som inte ska förväxlas. Det är Q-faktorn
 för en komponent respektive den för en hel strömkrets.
 
 Q-faktorn för en induktor är kvoten av dess reaktans och serieresistans.

--- a/koncept/chapter2-4.tex
+++ b/koncept/chapter2-4.tex
@@ -17,7 +17,7 @@ sekundärlindningarna - och alstrar där spänningar och strömmar.
 Den s.k. kopplingsfaktorn mellan lindningarna varierar för olika frekvenser, sämre
 vid låga frekvenser (hundratals Hz) och bättre vid höga frekvenser (tusentals
 Hz). Speciellt vid låga frekvenser behövs en bättre koppling för att avsedd
-effekt skall kunna överföras mellan lindningarna. Då kan ledningsförmågan i den
+effekt ska kunna överföras mellan lindningarna. Då kan ledningsförmågan i den
 magnetiska flödesvägen ökas med hjälp av en järnkärna.
 
 \begin{figure}[h]
@@ -167,7 +167,7 @@ Detta är en metod att spara in på antalet lindningar. För att t.ex. omsätta
 nätspänningen 230 V till 115 V används ibland en spartransformator.
 
 Med en spartransformator kommer olika strömkretsar i galvanisk förbindelse med
-varandra och särskild försiktighet skall därför iakttas vid användning av
+varandra och särskild försiktighet ska därför iakttas vid användning av
 sparkopplade transformatorer, p.g.a. risken för elolycksfall.
 Spartransformatorer bör därför inte användas i amatörradiosammanhang. Säkrast
 är transformatorer med galvaniskt skilda ledningar och dessutom med speciellt

--- a/koncept/chapter2-7.tex
+++ b/koncept/chapter2-7.tex
@@ -26,8 +26,8 @@ Dioden innehåller två elektroder
 \item k katod, med f f = glödtråd (filament)
 \end{itemize}
 
-\emph{Anoden} skall dra elektronerna från katoden.
-\emph{Katoden} skall avge elektronerna och måste därför hettas upp.
+\emph{Anoden} ska dra elektronerna från katoden.
+\emph{Katoden} ska avge elektronerna och måste därför hettas upp.
 
 Upphettningen av katoden görs på något av följande sätt:
 \begin{itemize}

--- a/koncept/chapter3-1.tex
+++ b/koncept/chapter3-1.tex
@@ -555,7 +555,7 @@ hastighet som ändringen har. När en en strömkrets med induktor
 bryts är det vanligt att det i brytögonblicket bildas en gnista eller ljusbåge
 över brytarens kontakter.
 
-Om induktansen är stor och kretsströmmen hög, så skall en stor mängd energi
+Om induktansen är stor och kretsströmmen hög, så ska en stor mängd energi
 frigöras på mycket kort tid. Det är därför inte ovanligt att brytarkontakter
 bränns eller smälter. I likströmskretsar kan gnistan eller ljusbågen minskas
 eller undertryckas genom att en kondensator i serie med en resistor kopplas

--- a/koncept/chapter3-3.tex
+++ b/koncept/chapter3-3.tex
@@ -109,9 +109,9 @@ induktansen L (s.k.  drossel) och glättningskondensatorn C 8 .
 Parallellt över denna kondensator ligger för elsäkerhetens skull en
 urladdningsresistor med hög resistans alltid inkopplad.
 
-Säkerhetsresistorn skall ladda ur kondensatorerna, när kraftaggregatet
+Säkerhetsresistorn ska ladda ur kondensatorerna, när kraftaggregatet
 inte är anslutet till strömförsörjningen och
-belastningen. Säkerhetsresistorn (eng. bleeder) skall vara av
+belastningen. Säkerhetsresistorn (eng. bleeder) ska vara av
 trådlindad typ och kunna tåla fyra gånger sin egen effektförbrukning.
 
 I obelastat tillstånd är spänningen över laddningskondensatorn

--- a/koncept/chapter3-4.tex
+++ b/koncept/chapter3-4.tex
@@ -163,18 +163,18 @@ spänningsförstärkning, men kan användas för s.k. impedansomvandling.
 
 \subsection{Stabilisering av arbetspunkten}
 
-För att en förstärkare skall kunna arbeta på avsett sätt måste
+För att en förstärkare ska kunna arbeta på avsett sätt måste
 arbetspunkten, d.v.s.  arbetsströmmens vilovärde ställas rätt.
 
 Det gör man genom att placera en förspänning över den styrande
 elektroden i elektronröret eller transistorn i fråga.
 
-I en katodkopplad rörförstärkare innebär det att styrgallret skall
+I en katodkopplad rörförstärkare innebär det att styrgallret ska
 ges en viss negativ spänning i förhållande till katoden. Det kan man
 göra t.ex. med en separat spänningskälla eller vanligare med en
 avkopplad resistor mellan katod och minuspolen (jord).
 
-I en emitterkopplad transistorförstärkare innebär det att basen skall
+I en emitterkopplad transistorförstärkare innebär det att basen ska
 ges en viss positiv spänning i förhållande till emittern. Det kan man
 göra t.ex. med en separat spänningskälla eller vanligare med en
 avkopplad resistor mellan emittern och minuspolen samt en resistiv
@@ -303,7 +303,7 @@ av insignalen. Denna överton förstärks i efterföljande förstärkarsteg,
 vilket också kan vara frekvensmultiplicerande.
 
 Ju högre multiplikationsfaktorn är, desto högre förspänning krävs för
-att svängningskretsen i utgången skall svänga obehindrat.  Med hög
+att svängningskretsen i utgången ska svänga obehindrat.  Med hög
 multipliceringsfaktor i ett enda steg dämpas signalen då så mycket att
 en hög förstärkning behövs i efterföljande steg. I praktiken anordnas
 därför en kedja av frekvensdubblande och frekvenstripplande Den totala
@@ -481,7 +481,7 @@ och anod, d.v.s.mellan in- och utgång. Därmed är risken för
 självsvängning betydligt mindre än i ett katodjordat steg.
 
 Uteffekten kan ökas genom att parallellkoppla två eller flera rör, som
-då skall ha så lika data som möjligt. Uteffekten står i direkt
+då ska ha så lika data som möjligt. Uteffekten står i direkt
 proportion till antalet rör.
 
 Flera parallellkopplade rör medför emellertid ökade totala
@@ -638,7 +638,7 @@ Vid överstyrning uppstår signalförvrängningar, som medför
 intermodulation, förvrängt tal, splatterstörningar och övertoner.  Den
 extra effektökning som uppnås med överstyrning förbrukas i stort sett
 till signalförvrängning och kommer inte nyttosignalen till
-godo. Överstyrning skall därför undvikas.
+godo. Överstyrning ska därför undvikas.
 
 Drivstegets uteffekt får inte vara så stor att slutsteget blir
 överstyrt. Ett slutsteg med jordad katod blir fullt utstyrt redan vid

--- a/koncept/chapter3-5.tex
+++ b/koncept/chapter3-5.tex
@@ -151,7 +151,7 @@ LF-spänning som motsvarar det utsända talet.
 
 Bild \ref{fig:BildII3-58}
 
-Demoduleringen skall ske med mottagaren inställd mitt på avsedd
+Demoduleringen ska ske med mottagaren inställd mitt på avsedd
 sändarfrekvens.  Ett hjälpmedel för det är en indikator, som vid rätt
 inställning visar värdet noll. Positivt eller negativt utslag anger
 att inställningen är för högt respektive för lågt i frekvens. En sådan

--- a/koncept/chapter3-6.tex
+++ b/koncept/chapter3-6.tex
@@ -37,7 +37,7 @@ Stöt nu till pendeln varje gång, som den pendlar tillbaka. För lika
 stora utslag varje gång - en odämpad svängning - fordras det upprepade
 energitillskott som precis kompenserar förlusterna.
 
-Villkoren för att en svängning skall fortgå (vara odämpad) är att
+Villkoren för att en svängning ska fortgå (vara odämpad) är att
 energitillskotten
 \begin{itemize}
 \item kommer vid rätt tidpunkt,
@@ -137,7 +137,7 @@ stället en ton med samma frekvens som filtrets resonansfrekvens.
 
 En oscillator med inställbar frekvens kallas för VFO (variabel
 frekvensoscillator). Förutom frekvensstabilitet fordras också, att
-noggrann inställning och avläsning av frekvensen skall kunna göras.
+noggrann inställning och avläsning av frekvensen ska kunna göras.
 
 En LC-oscillator är urtypen för en oscillator med variabel
 frekvens. Meissner-kopplingen är lätt att urskilja och används här för
@@ -207,7 +207,7 @@ signalen fås då sambandet
 \[\hat{U}_k = -k \cdot \hat{U}_{ut}\]
 
 Tillräcklig signalspänning från utgången måste återföras till ingången
-för att det skall uppstå självsvängning. Det sker när den återkopplade
+för att det ska uppstå självsvängning. Det sker när den återkopplade
 signalspänningen \(\hat{U}_k\) är minst lika stor som
 ingångsspänningen \(\hat{U}_{in}\) och är i rätt fasläge, d.v.s. i
 detta exempel
@@ -228,7 +228,7 @@ k \geq \frac{1}{A}
 k \cdot A \geq 1
 \]
 
-Ett \(k \cdot A \approx 3\) är önskvärt för att oscillatorn skall
+Ett \(k \cdot A \approx 3\) är önskvärt för att oscillatorn ska
 svänga igång snabbt.
 
 \subsubsection{Hartley-koppling}

--- a/koncept/chapter3-7.tex
+++ b/koncept/chapter3-7.tex
@@ -363,12 +363,12 @@ skärmning och filtrering.
 \index{frekvensstabilitet}
 \index{oscillator!stabilitet}
 
-Sändarens frekvens skall hållas så stabil som möjligt. En ostabil
+Sändarens frekvens ska hållas så stabil som möjligt. En ostabil
 sändare är inte godtagbar och skapar svårigheter inte bara för de
 radiostationer som deltar i förbindelsen utan även för radiotrafiken
 på närliggande frekvenser.
 
-En frekvensstabil oscillator skall ha följande egenskaper:
+En frekvensstabil oscillator ska ha följande egenskaper:
 
 \emph{Stabil mekanisk uppbyggnad}
 
@@ -376,7 +376,7 @@ Skakningar från underlaget t.ex. vid mobilt bruk, vibrationer från en
 transformatorkärna etc. kan försämra oscillatorns frekvensstabilitet.
 
 Frekvensbestämmande komponenter såsom fasta och variabla
-kondensatorer, spolar etc skall vara stabilt monterade, trimkärnorna i
+kondensatorer, spolar etc ska vara stabilt monterade, trimkärnorna i
 spolarna fixerade o.s.v.
 
 Förbindningarna får inte tillåtas att böja sig eller
@@ -391,14 +391,14 @@ och kopplingsställen fullgoda. Induktorer och kondensatorer i
 svängningskretsarna måste vara förlustfattiga och högvärdiga i övrigt
 så att signalen blir så ren som möjligt från oönskade sidofrekvenser.
 
-Återkopplingen i oscillatorn skall vara så fast (kraftig) att
+Återkopplingen i oscillatorn ska vara så fast (kraftig) att
 självsvängningen är stabil.  Men för att få en renast möjlig signal
 får kopplingen inte vara så fast, att svängningskretsarna blir alltför
 belastade och deras godhetstal för lågt.
 
 \emph{Avskärmande kapslingar}
 
-Svängningskretsar skall skärmas från yttre kapacitanstillskott
+Svängningskretsar ska skärmas från yttre kapacitanstillskott
 (t.ex.från en hand) Det görs med skiljeväggar och komponentkapslingar
 av metall. Skärmningarna förhindrar också oönskad koppling mellan
 oscillatorn och efterföljande förstärkare genom elektriska och
@@ -433,7 +433,7 @@ Särskilt varierande belastning över oscillatorns utgång medför
 frekvensändring. Oscillatorn bör därför ges en så låg och stabil
 belastning som möjligt. Ett buffertsteg kopplas därför in efter
 oscillatorn. Det bör ha hög ingångsimpedans för att belasta
-oscillatorn så lite som möjligt. Det skall också kunna lämna
+oscillatorn så lite som möjligt. Det ska också kunna lämna
 tillräcklig driveffekt till efterföljande förstärkare och bör därför
 ha låg utgångs impedans. Det måste dessutom arbeta linjärt (se klass
 A-drift, bild \ref{fig:BildII3-44}) för att inte alstra övertoner och därmed
@@ -450,7 +450,7 @@ totala temperaturberoendet kan kompenseras genom ett antal åtgärder.
 
 Oscillatorn bör monteras så långt bort som möjligt från övriga
 värmealstrande komponenter. Den avskärmande kapslingen omkring
-oscillatorn skall vara så tjockväggig och värmeisolerande som
+oscillatorn ska vara så tjockväggig och värmeisolerande som
 möjligt. Inbyggnad i en termostatreglerad kapsling är ett ännu bättre
 alternativ.
 

--- a/koncept/chapter3-8.tex
+++ b/koncept/chapter3-8.tex
@@ -241,7 +241,7 @@ frekvenser.
 
 Bild \ref{fig:BildII3-88}
 
-I ett tidigare avsnitt har vi beskrivit en s.k.  super-VFO. Vi skall
+I ett tidigare avsnitt har vi beskrivit en s.k.  super-VFO. Vi ska
 nu undersöka vilka blandningsprodukter som uppstår i en sådan. De två
 mest uppenbara frekvenserna är blandningsprodukterna (summan) i
 området 144-146 MHz och (skillnaden) i området 128-126 MHz.

--- a/koncept/chapter3-9.tex
+++ b/koncept/chapter3-9.tex
@@ -122,7 +122,7 @@ avsnitt \ref{modulation}).
 
 En J3E-modulator enligt filtermetoden består således av en balanserad
 blandare ofta en s.k. ringblandare (se bild \ref{fig:BildII3-87} i avsnitt
-\ref{blandare}) samt ett bandpassfilter.  För att SSB-signalen skall få avsedd
+\ref{blandare}) samt ett bandpassfilter.  För att SSB-signalen ska få avsedd
 sändarfrekvens kan ytterligare frekvensblandning behövas (se kapitel
 \ref{sändare}).
 

--- a/koncept/chapter4-2.tex
+++ b/koncept/chapter4-2.tex
@@ -61,7 +61,7 @@ Mindre belastning kan åstadkommas på två sätt; dels med ``lösare''
 koppling mellan antennkrets och svängningskrets och dels med bättre
 impedansanpassning mellan svängningskrets och diod. Båda sätten
 tillämpas i Bild \ref{fig:bildII4-3}. Hur selektionen då förbättras visas i
-Bild \ref{fig:bildII4-4}, vilket skall jämföras med Bild \ref{fig:bildII4-2}.
+Bild \ref{fig:bildII4-4}, vilket ska jämföras med Bild \ref{fig:bildII4-2}.
 
 \begin{figure}
   \includegraphics[width=\textwidth]{images/bild_2_4-03}
@@ -237,7 +237,7 @@ bilden.
 
 Med en bärvågsfrekvens av 1835 kHz motsvaras dessa modulerande
 frekvenser av utfrekvenserna 1834.7, 1834 och 1832 kHz. VFO ersätter
-SSB-sändarens bärvåg och skall ha samma frekvens - 1835 kHz - för att
+SSB-sändarens bärvåg och ska ha samma frekvens - 1835 kHz - för att
 kunna återge 300, 1000 och 3000 Hz.
 
 \subsection{Selektionen i direktblandade mottagare}

--- a/koncept/chapter4-3.tex
+++ b/koncept/chapter4-3.tex
@@ -41,7 +41,7 @@ som är vanlig i äldre mottagare. MF-filtret kan i enklaste fall bestå av
 avstämningsskärpa fås med resonatorer av keramik eller kvarts eller med
 hjälp av elektromekaniska resonatorer.
 
-Exempel: En sändning på frekvensen 3600 kHz skall tas emot. Vi ställer
+Exempel: En sändning på frekvensen 3600 kHz ska tas emot. Vi ställer
 då in VFO-frekvensen till 4055 kHz, eftersom mellanfrekvensen är
 \(4055 - 3600 = 455\) kHz. Den mottagna signalen hamnar då mitt i
 MF-filtrets passband.

--- a/koncept/chapter4-6.tex
+++ b/koncept/chapter4-6.tex
@@ -17,7 +17,7 @@ till ett annat, så används en mottagningskonverter där
 frekvensblandning och frekvensfilter används.
 
 Konvertern fungerar som tillsats före en mottagare för att denna även
-skall kunna användas inom ett annat frekvensområde. I en konverter är
+ska kunna användas inom ett annat frekvensområde. I en konverter är
 oscillatorfrekvensen fast, medan avsökningen av frekvensområdet görs
 med VFO i mottagaren. Mellanfrekvensfiltret i mottagaren är så brett
 som hela det frekvensområde som tas emot av konvertern och avsöks med

--- a/koncept/chapter4-8.tex
+++ b/koncept/chapter4-8.tex
@@ -5,7 +5,7 @@
 \index{mottagare!automatisk förstärkningsreglering}
 \index{mottagare!AGC}
 
-För att mottagaren skall fungera bra för såväl mycket svaga som för
+För att mottagaren ska fungera bra för såväl mycket svaga som för
 mycket starka insignaler behövs en förstärkningsreglering i
 signalvägen genom mottagaren. Signalspänningen på mottagaringången kan
 vara från delar av en mikrovolt upp till över 100 millivolt - ett
@@ -149,4 +149,4 @@ bruset. I mottagare för flera sändningsslag och därför även AGC kan
 denna funktion styra brusspärren, men i en ren FM-mottagare arbetar
 MF-förstärkarna utan AGC. I det fallet behövs någon annan anordning för
 att skilja mellan en modulerad signal och brus. Ofta finns ett reglage
-(squelch) för hur stark signalen skall vara innan spärren öppnar.
+(squelch) för hur stark signalen ska vara innan spärren öppnar.

--- a/koncept/chapter4-9.tex
+++ b/koncept/chapter4-9.tex
@@ -32,7 +32,7 @@ för att utskilja den önskade signalen efter blandningsförloppen.
 
 Bild \ref{fig:bildII4-22}
 
-Exempel: En sändning på 3600kHz skall tas emot och VFO-frekvensen är
+Exempel: En sändning på 3600kHz ska tas emot och VFO-frekvensen är
 4055 kHz. Mellanfrekvensfiltret undertrycker sändningar på så
 närliggande frekvenser som t.ex. 3603 och 3597 kHz. Denna egenskap
 kallas för närselektion.
@@ -78,7 +78,7 @@ Bild \ref{fig:bildII4-24}
 Ju längre ifrån varandra nyttofrekvens och spegelfrekvens ligger,
 desto bättre är förselektionen. Med en mellanfrekvens av 455 kHz är
 alltså detta avstånd 910 kHz. I långvågs- och mellanvågsområdet är det
-tillräckligt för att man med enkla medel skall kunna skapa
+tillräckligt för att man med enkla medel ska kunna skapa
 tillräckligt selektiva filter.
 
 Exempel: Vid den högsta mottagningsfrekvensen på mellanvåg 1605 kHz är
@@ -169,7 +169,7 @@ mindre störd mottagning.
 
 Bild \ref{fig:bildII4-27}
 
-Mellanfrekvensfiltret för SSB-mottagning skall endast släppa igenom
+Mellanfrekvensfiltret för SSB-mottagning ska endast släppa igenom
 ett av de två sidbanden, vars bredd är skillnaden mellan högsta och
 lägsta överförda LF-frekvens.  Inom amatörradio är detta 3 kHz - 0,3 kHz
 = 2,7 kHz, alltså något mindre än hälften av bandbredden vid AM.
@@ -328,7 +328,7 @@ rad specifika bruskällor:
 
 Det bildas en sammanlagd brusspänning som kan bestämmas. Man talar om
 ett brustal, som är ett mått på mottagningssystemets egenbrus. Detta
-skall ställas mot styrkan på den mottagna signalen. Man talar om ett
+ska ställas mot styrkan på den mottagna signalen. Man talar om ett
 förhållande mellan signaleffekt och bruseffekt. Det finns flera
 metoder att mäta och uttrycka detta förhållande som kallas S/N (signal
 to noise ratio). För att uppfatta den information som kommer ur en
@@ -407,7 +407,7 @@ mottagaren i AM-läge ställt in den på någon bärvåg så hörs också andra
 starka, frekvensnära stationer.
 
 Det måste alltså alltid finnas en nyttosignal på den inställda
-frekvensen för att det skall uppstå korsmodulation. När nyttosignalen
+frekvensen för att det ska uppstå korsmodulation. När nyttosignalen
 försvinner så försvinner även korsmodulationen.
 
 \subsection{Intermodulation}

--- a/koncept/chapter5-1.tex
+++ b/koncept/chapter5-1.tex
@@ -204,7 +204,7 @@ I en SSB-signal ligger all information i amplituden, till skillnad
 från en FM-signal där all information ligger i frekvensen. En
 SSB-signal får alltså inte förvrängas. Det innebär att
 förstärkarstegen i SSB-sändare måste arbeta linjärt, d.v.s. en
-utsignal skall vara proportionell till insignalen i varje moment.
+utsignal ska vara proportionell till insignalen i varje moment.
 
 \subsection{PLL-styrda sändare}
 \index{PLL}
@@ -300,7 +300,7 @@ Summafrekvensen 70 MHz filtreras fram som mellanfrekvens. Den önskade
 sändningsfrekvensen fås genom att blanda 70 MHz MF med frekvensen från
 VCO och därefter filtrera fram skillnadsfrekvensen.  VCO i detta
 exempel täcker frekvensområdet 40 - 69,5 MHz. Således blir sändarens
-täckningsområde 1,5 - 30 MHz. För att filterfunktionen skall bli
+täckningsområde 1,5 - 30 MHz. För att filterfunktionen ska bli
 optimal, kan den delas upp på flera valbara filtersektioner, t.ex. ett
 per amatörband. Valet kan ske automatiskt och styrt av frekvensläget
 på VCO.

--- a/koncept/chapter5-2.tex
+++ b/koncept/chapter5-2.tex
@@ -77,7 +77,7 @@ räkneexempel för två frekvenskanaler. Det frekvenssving i oscillatorn,
 som alstras av modulatorn, multipliceras också med 12.  För ett sving
 av 3 kHz på bärvågen är svinget på oscillatorn bara 250 Hz.
 
-Efter mikrofonförstärkaren följer en amplitudbegränsare, som skall
+Efter mikrofonförstärkaren följer en amplitudbegränsare, som ska
 hålla deviationen inom ett givet maxvärde, oavsett signalstyrkan från
 mikrofonen. Därefter följer ett lågpassfilter, som dels dämpar de
 övertoner som uppstår vid amplitudbegränsningen och dels begränsar de
@@ -139,7 +139,7 @@ modulatorn. Liksom i den station med kanalkristaller, som beskrivits i
 bild \ref{fig:bildII5-12}, är mottagaren även i detta fall en dubbelsuper.
 
 VCO används även som lokaloscillator i mottagaren. Eftersom sändaren
-och mottagaren skall användas på samma frekvens (simplextrafik), måste
+och mottagaren ska användas på samma frekvens (simplextrafik), måste
 i detta koncept VCO-frekvensen vara olika vid sändning och
 mottagning. Eftersom mottagarens mellanfrekvens MF är 10,7 MHz måste
 nämligen VCO ligga 10,7 MHz högre eller lägre vid mottagning än vid

--- a/koncept/chapter6-1.tex
+++ b/koncept/chapter6-1.tex
@@ -200,7 +200,7 @@ nämnvärd påverkan från omgivningen. I praktiken kan impedansen avvika
 mycket från detta värde.
 
 Antenn och matningskabel måste vara impedansanpassade till varandra
-för att det inte skall skall uppstå vågreflexion i anslutningen.
+för att det inte ska uppstå vågreflexion i anslutningen.
 
 Märk, att halvvågsantennen är i resonans inte bara på grundtonen utan
 även på jämna övertoner, 2:a, 4:e etc. harmoniska, varvid
@@ -364,7 +364,7 @@ markplanet. En horisontelit upphängd antenn med en längd av
 höjd av \(\lambda/2\), \(\lambda\), \(3\lambda/2\), \(2\lambda\),
 o.s.v. över mark. När en horisontell antenn däremot placeras
 \(\lambda/4\), \(3\lambda/4\), \(5\lambda/4\) o.s.v. över mark, är
-utstrålningen övervägande vertikal, vilket inte skall förväxlas med
+utstrålningen övervägande vertikal, vilket inte ska förväxlas med
 polarisationen, som i detta fall är horisontell.
 
 Samma diagram gäller både för en sändar- och mottagarantenn. styrkan

--- a/koncept/chapter6-2.tex
+++ b/koncept/chapter6-2.tex
@@ -18,7 +18,7 @@ Polarisationsriktningen på de utsända radiovågorna beror i främst på
 sändarantennens utförande.
 
 \subsection{Polarisation på HF - Kortvåg}
-För bästa mottagning skall användas en antenn för samma
+För bästa mottagning ska användas en antenn för samma
 polarisationsriktning som i den infallande vågen. Vilken polarisation
 man väljer är av mindre betydelse än att den bör vara lika både i
 sändar-och mottagarantennen. På kortvåg är det nödvändigtvis inte

--- a/koncept/chapter6-4.tex
+++ b/koncept/chapter6-4.tex
@@ -16,7 +16,7 @@ riktningar, låtvara mest vinkelrätt ut från antennen, så är energin i
 flesta riktningarna att ses som ``förlorad''. När ett passivt
 antennelement - en reflektor - placeras bakom det aktiva elementet kan
 emellertid bakåtstrålningen delvis vändas framåt och man får i stället
-en viss riktverkan. För att det skall fungera skall de båda elementen
+en viss riktverkan. För att det ska fungera ska de båda elementen
 ha en viss inbördes längd och ett visst avstånd emellan.
 
 

--- a/koncept/chapter6-6.tex
+++ b/koncept/chapter6-6.tex
@@ -1,9 +1,9 @@
 \section{Transmissionsledningar}
 \label{transmissionsledningar}
 
-En matarledning skall med så små förluster som möjligt överföra den
+En matarledning ska med så små förluster som möjligt överföra den
 högfrekventa energin från sändaren fram till sändarantennen.  Omvänt
-skall den energi som fångats upp av mottagarantennen transporteras
+ska den energi som fångats upp av mottagarantennen transporteras
 till mottagaren med så små förluster som möjligt.
 
 \subsection{Avstämd matarledning}
@@ -34,7 +34,7 @@ I vardera änden av \(\lambda/2\)-dipolen uppträder en spänningsbuk
 (heldragna linjer). Den stående vågen, med strömbuken på dipolens
 mitt, fortsätter ner på \(\lambda/4\)-matarledningen. I nedre änden av
 matarledningen vid sändarutgången har det uppstått en strömnod och en
-spänningsbuk, vilket innebär att matarledningen skall spänningskopplas
+spänningsbuk, vilket innebär att matarledningen ska spänningskopplas
 till sändaren.
 
 \begin{wrapfigure}[19]{R}{0.5\textwidth}
@@ -47,7 +47,7 @@ Bild \ref{fig:bildII6-22}
 
 Om matarledningen i stället är \(\lambda/2\) lång, så uppstår i
 stället en spänningsnod och en strömbuk i nedre änden av ledningen,
-vilket innebär att matarledningen skall strömkopplas till sändaren.
+vilket innebär att matarledningen ska strömkopplas till sändaren.
 
 Ström- och spänningsfördelningen kan ritas upp för en
 \(\lambda\)-dipol resp.  \(\lambda/2\)-dipol i kombination med
@@ -513,7 +513,7 @@ matarledningens impedans.
 
 Bild \ref{fig:bildII6-32}
 
-Funktion: När t.ex. en omvikt dipol med matningsimpedansen 240 Ω skall
+Funktion: När t.ex. en omvikt dipol med matningsimpedansen 240 Ω ska
 anslutas till en 50 Ω-kabel, behövs en impedanstransformering med
 förhållandet 4:1. En \(\lambda/2\) lång fasningsledning kan användas för detta
 ändamål. Fasningsledningen har dessutom en strömbalanserande verkan.

--- a/koncept/chapter7-1.tex
+++ b/koncept/chapter7-1.tex
@@ -90,7 +90,7 @@ ständigt, omväxlande emot respektive ifrån varandra. Tänk på två kulor
 i var sin ände av en spiralfjäder. Avståndet mellan laddningarna
 ändras i takt med styrkan och riktningen på strömmen. Systemet är
 alltså under ständig hastighetsändring (ökning resp. minskning),
-vilket är förutsättningen för att energi skall strålas ut.
+vilket är förutsättningen för att energi ska strålas ut.
 
 Först är laddningarna nära varandra på grund av liten laddning. Vid
 ökande ström ökar avståndet mellan laddningarna och det byggs upp ett

--- a/koncept/chapter7-3.tex
+++ b/koncept/chapter7-3.tex
@@ -6,13 +6,13 @@ HAREC a.\ref{HAREC.a.7.3}\label{myHAREC.a.7.3}
 Jonosfären har fått namnet från begreppet jon, som är en fri elektron
 eller annan laddad partikel. Jonisering- elektrisk uppladdning av
 jordatmosfären sker mellan c:a 40 - 400 km över jordytan. Där är
-lufttrycket tillräckligt lågt för att joner skall kunna röra sig fritt
+lufttrycket tillräckligt lågt för att joner ska kunna röra sig fritt
 under avsevärd tid utan att kollidera och återförena sig till neutrala
 atomer.
 
 När en radiovåg passerar genom ett joniserat skikt i atmosfären,
 kan vågen ändra riktning, vilket kallas för refraktion. För att
-refraktion skall uppstå måste i första hand två villkor uppfyllas, det
+refraktion ska uppstå måste i första hand två villkor uppfyllas, det
 är tillräckligt tät jonisering och tillräckligt lång våglängd. Under
 ``gynnsamma'' omständigheter kan vågorna till och med böjas av ner mot
 jorden, vilket är den viktigaste förutsättningen för långväga
@@ -139,7 +139,7 @@ Rymdvågen måste träffa ett joniserat atmosfärskikt med en tillräckligt
 flack vinkel för att reflekteras, den s.k. kritiska vinkeln. Denna
 vinkel är frekvensberoende. Allt eftersom den utsända frekvensen ökas
 ytterligare över den kritiska frekvensen, måste vågen träffa
-atmosfärskiktet i en allt flackare vinkel för att vågen skall
+atmosfärskiktet i en allt flackare vinkel för att vågen ska
 reflekteras mot jordytan.  att sända ut vågen i mycket flack vinkel
 mot \(\mathrm{F_2}\)-skiktet kan långa distanser överbryggas den vid
 frekvenser som är upp till 3,5 gånger den kritiska frekvensen.

--- a/koncept/chapter8-1.tex
+++ b/koncept/chapter8-1.tex
@@ -19,8 +19,8 @@ spänning.
 Mätströmmen påverkar emellertid spänningsfördelningen i kretsen och då
 uppstår ett mätfel, vilket inte framgår av det visade mätvärdet. Med
 kännedom om kretsens och instrumentets data kan man dock beräkna
-mätfelet. En voltmeter skall ha hög inre resistans för att mätfelet
-skall bli litet.
+mätfelet. En voltmeter ska ha hög inre resistans för att mätfelet
+ska bli litet.
 
 Endast vid mycket noggrann mätning kan man behöva räkna om det visade
 mätvärdet med hänsyn till voltmeterns inre resistans och
@@ -46,17 +46,17 @@ skalor. I digitala voltmetrar anpassas ``skalan'' oftast automatiskt.
 \subsection{Mäta likström}
 
 Vid strömmätning bestämmer man strömstyrkan i en gren av en elektriskt
-strömkrets.  Amperemetern skall kopplas i serie med den aktuella
+strömkrets.  Amperemetern ska kopplas i serie med den aktuella
 strömgrenen.  Det visade mätvärdet motsvarar strömstyrkan.
 Amperemeterns inre resistans adderas emellertid till resistansen i
-strömgrenen och då uppstår ett mätfel.  En amperemeter skall ha låg
-inre resistans för att mätfelet skall bli litet.
+strömgrenen och då uppstår ett mätfel.  En amperemeter ska ha låg
+inre resistans för att mätfelet ska bli litet.
 
 Endast vid mycket noggrann mätning kan man behöva räkna om det visade
 mätvärdet med hänsyn till amperemeterns inre resistans och resistansen
 i strömshunten-om en sådan används.
 
-\emph{På grund av den låga inre resistansen skall en amperemeter
+\emph{På grund av den låga inre resistansen ska en amperemeter
   ALDRIG användas för spänningsmätning. Då förstörs den!}
 
 \subsubsection{Utöka mätområdet för en amperemeter}
@@ -68,7 +68,7 @@ mäta högre ström än den som amperemetern är gjord för.
 
 Shunten dimensioneras så att större delen av strömmen leds förbi
 amperemetern.  Kvar är den mätström som behövs för att amperemetern
-skall göra fullt utslag.
+ska göra fullt utslag.
 
 Mätströmmen fördelar sig omvänt proportionellt till instrumentets och
 shuntens resistanser.
@@ -253,7 +253,7 @@ delaren kan övertoner passera lättare.
 
 Denna mätmetod är noggrann bara när impedansen är lika i sändaren,
 kabeln till lasten och själva lasten. Lasten kan vara en konstlast, en
-antenn etc och skall ha ett känt värde för att effekten skall kunna
+antenn etc och ska ha ett känt värde för att effekten ska kunna
 beräknas.
 
 Ett sätt att skaffa underlag för beräkning av PEP-effekten är att mäta

--- a/koncept/chapter8-2.tex
+++ b/koncept/chapter8-2.tex
@@ -43,7 +43,7 @@ effektförbrukning och stor noggrannhet.  Visningen är vanligen linjär,
 men kan göras annorlunda.
 
 Funktion: En spole är upplagrad i fältet av en hästskomagnet När den
-ström, som skall mätas, passerar genom den vridbara spolen så alstras
+ström, som ska mätas, passerar genom den vridbara spolen så alstras
 ett magnetfält även i denna. De två magnetfälten påverkarvarandra så
 att spolen vrider sig. Spolen förses med en visare och en
 returfjäder. Ju större ström det flyter genom spolen desto större blir
@@ -94,11 +94,11 @@ att då undvika att energi strålas ut bör en väl skärmad konstlast
 användas.
 
 I moderna amatörradiosändare med koaxialkabel utgång är
-utgångsimpedansen 50 Ω. Konstlasten skall då vara en 50 Ω resistor
+utgångsimpedansen 50 Ω. Konstlasten ska då vara en 50 Ω resistor
 utan reaktiva egenskaper.  Den kan bestå av en eller flera
 sammankopplade resistorer.
 
-Sändareffekten skall kunna tas upp utan att resistansen förändras
+Sändareffekten ska kunna tas upp utan att resistansen förändras
 nämnvärt. Det är viktigt att resistorerna kyls effektivt med luft
 eller vätska i ett kärl med tillräckligt utrymme, även när vätskan
 expanderar av värmen.  Vätskan får inte vara lättantändlig eller
@@ -221,7 +221,7 @@ HF-mätningar. En SVF-meter kan ha separata instrument för fram-
 respektive backeffekt eller ett gemensamt.
 
 SVF-metern kan vara ständigt inkopplad t.ex. mellan sändare och
-antenn, men skall då kunna tåla effektutvecklingen. En SVF-meter kan
+antenn, men ska då kunna tåla effektutvecklingen. En SVF-meter kan
 alstra övertoner, vilka kan medföra störningar. Orsaken är
 olinjäriteten halvledardioderna i instrumentet.
 
@@ -269,7 +269,7 @@ Absorbtionsvågmetern används för att bestämma en oscillators
 arbetsfrekvens. Den består av en resonanskrets med variabel frekvens,
 som kan avläsas, och ett mätinstrument som resonansindikator.
 
-Vågmetern kopplas induktivt till den krets, vars frekvens skall
+Vågmetern kopplas induktivt till den krets, vars frekvens ska
 bestämmas. När frekvensen i kretsen och vågmetern stämmer överens, ger
 resonansindikatorn utslag. Frekvensen avläses då på vågmeterns skala.
 
@@ -350,7 +350,7 @@ modulationskvalitet o.s.v. åskådliggöras.
 
 Oscilloskopet består av ett katodstrålerör, där styrningen av
 katodstrålen sker med hjälp av X- och Y-förstärkare och en s.k.
-triggerförstärkare. Den signal som skall mätas ansluts vanligen till
+triggerförstärkare. Den signal som ska mätas ansluts vanligen till
 Y-förstärkaren medan en tidbasgenerator som alstrar en sågtandformad
 signal ansluts till X-förstärkaren.  Bilden visar ett blockschema på
 oscilloskop.

--- a/koncept/chapter9-1.tex
+++ b/koncept/chapter9-1.tex
@@ -18,7 +18,7 @@ Samlingsbegreppet är \emph{Electromagnetic Compatibility} (EMC), d.v.s. en
 apparats förmåga att fungera tillfredsställande i sin elektromagnetiska
 omgivning utan att alstra elektromagnetiska störningar som överstiger en nivå,
 som tillåter radio- och teleutrustning och andra apparater att fungera som
-avsett. Vidare skall apparater ha en sådan tillräcklig inbyggd tålighet mot
+avsett. Vidare ska apparater ha en sådan tillräcklig inbyggd tålighet mot
 elektromagnetiska störningar, att de kan fungera som avsett.
 
 Till skydd för liv, personlig säkerhet och hälsa samt kommunikationer och
@@ -70,7 +70,7 @@ Post- och telestyrelsens föreskrifter om undantag från tillståndsplikt för
 användning av vissa radiosändare 3 Kap 14§ \emph{De tekniska egenskaperna hos
 amatörradiosändaren ska anpassas så att de inte stör användningen av andra
 radioanläggningar.} Samt skrivningen i Strålsäkerhetsmyndighetens SSMFS 2008:18.
-Medför att sändareffekten alltid skall anpassas så att styrkan av utstrålade
+Medför att sändareffekten alltid ska anpassas så att styrkan av utstrålade
 fält inte förorsakar störningar eller för höga nivåer av elektromagnetiska fält.
 
 Den enligt undantagsföreskrifterna högsta tillåtna effekten kan alltså inte användas hinderslöst.
@@ -83,7 +83,7 @@ vissa tider, på vissa frekvenser, över viss sändareffekt etc.
 \begin{itemize}
 \item Störningar är alltid förenade med obehag och ställer grannsämjan
   på prov. Håll Dig väl med dem som bor i omgivningen!
-\item Om det väcks klagomål på Dig om störningar, skall Du först
+\item Om det väcks klagomål på Dig om störningar, ska Du först
   kontrollera Din egen sändare och antennanläggning.
 \item Be därefter att få undersöka antennanläggning och apparater hos
   den som besväras av störningar.

--- a/koncept/chapter9-4.tex
+++ b/koncept/chapter9-4.tex
@@ -17,7 +17,7 @@ och genom strålning. I mottagarfallet kan HF-signaler uppfångas av nätledning
 ledas in i apparaterna och LF-detekteras där. För att förhindra sådana
 störningar behövs ett nätfilter.
 
-Nätfiltret skall vara dimensionerat för den nätström, som apparaten är avsäkrad
+Nätfiltret ska vara dimensionerat för den nätström, som apparaten är avsäkrad
 för och bör anslutas så nära apparaten som möjligt. Om filtret inte kan placeras
 där, kan det vara nödvändigt att även skärma nätledningen mellan filtret och
 apparaten och jorda skärmen.
@@ -65,7 +65,7 @@ f.ö. alla filter.
 
 Utstrålning utanför sändningsslagets tillåtna bandbredd anses som
 ``icke önskad utstrålning''. Vidare gäller att sådan utstrålning från
-amatörradiosändare skall hållas så låg som dagens amatörradioteknik medger.
+amatörradiosändare ska hållas så låg som dagens amatörradioteknik medger.
 Bild \ref{fig:bildII9-2} visar principen för lågpassfiltret TP 30 för kortvåg,
 med gränsfrekvensen 36 MHz, att kopplas mellan sändaren och antennledningen.
 Med denna gränsfrekvens dämpas övertoner från sändare så att risken för
@@ -124,12 +124,12 @@ serie med mottagaringången (Bild \ref{fig:bildII9-5}). Kretsen består av en
 induktans och en kapacitans.
 
 Om man använder en stub som resonanskrets - t.ex. en koaxialkabel - så
-skall den ha längden \(\lambda/4\) och vara ``kortsluten'' eller ha
+ska den ha längden \(\lambda/4\) och vara ``kortsluten'' eller ha
 längden \(\lambda/2\) och vara ``öppen''.
 
 Man kan även kortsluta - ``suga bort'' den störande signalen med en
 serieresonanskrets parallellt över mottagaringången (Bild \ref{fig:bildII9-6}). Om
-man då använder en stub, så skall den ha längden \(\lambda/4\) och
+man då använder en stub, så ska den ha längden \(\lambda/4\) och
 vara ``öppen'' eller ha längden \(\lambda/2\) och vara ``kortsluten''.
 
 Den störande signalen kan undertryckas ytterligare med fler stubar,

--- a/koncept/emf.tex
+++ b/koncept/emf.tex
@@ -580,9 +580,9 @@ ström och därmed kommer matningsledningen sluta att agera radierande
 element, varvid fältstyrkorna sjunker signifikant.
 
 \item Vissa antenner, så som T-antenn, använder dock obalansen för att
-matningsledningen agerar radierande element. I dessa fall skall den delen
+matningsledningen agerar radierande element. I dessa fall ska den delen
 av matningsledningen som agerar radierande element betraktas som sådant även
-i EMF-sammanhang och säkerhetsavstånd skall iakttas. Det är rekommenderat att
+i EMF-sammanhang och säkerhetsavstånd ska iakttas. Det är rekommenderat att
 använda ström-balun för att isolera antennen från radio-stationen med
 avseende på gemensam ström.
 

--- a/koncept/morse.tex
+++ b/koncept/morse.tex
@@ -35,7 +35,7 @@ användning.
 %\begin{rev-omarbetas}
 %För tillträde till amatörradiofrekvenserna på kortvåg (under 30 MHz),
 %där trafiken är tät och räckvidden lång, föreskrivs fortfarande i det
-%internationella radioreglementet att radioamatörerna skall ha färdighet i
+%internationella radioreglementet att radioamatörerna ska ha färdighet i
 %morsesignalering.
 %\end{rev-omarbetas}
 
@@ -50,10 +50,10 @@ användning.
 Bild \ref{fig:bild_morse_1}.
 
 Morsetecknen består av korta och långa teckendelar samt mellanrum. Man utgår från
-den korta teckendelen vars längd sätts till en enhet. En lång teckendel skall
+den korta teckendelen vars längd sätts till en enhet. En lång teckendel ska
 vara tre enheter lång, d.v.s. tre gånger längden av den korta
-teckendelen. Mellan teckendelarna inom tecknet skall mellanrummet vara en enhet
-långt. Mellan hela tecknen inom ord eller teckengrupp skall mellanrummet vara
+teckendelen. Mellan teckendelarna inom tecknet ska mellanrummet vara en enhet
+långt. Mellan hela tecknen inom ord eller teckengrupp ska mellanrummet vara
 tre enheter långt och mellan hela ord eller teckengrupper sju enheter långt.
 
 \section{Planlagd övning}
@@ -141,15 +141,15 @@ morsetecken grundligt genom mottagning är det dags med sändningsträning.
 \section{Mottagnings\-övningar}
 
 Morsetecken är ju långa och korta teckendelar i form av ljud, ljus etc. De kan
-även illustreras som långa och korta streck. För att tecknen skall uppfattas som
-en melodi eller ljudföljd och för att man inte skall frestas att räkna korta
+även illustreras som långa och korta streck. För att tecknen ska uppfattas som
+en melodi eller ljudföljd och för att man inte ska frestas att räkna korta
 eller långa teckendelar är lämpligt att morsetecknen lärs in i hög hastighet,
 men med förlängt mellanrum, s.k. spärrad stil. Det är själva ljudbilden som
-skallläras in. I början kan det ändå vara svårt att låta bli att räkna
+ska läras in. I början kan det ändå vara svårt att låta bli att räkna
 teckendelar, men efterhand uppfattar man trots allt tecknen som ljudbilder.
 
-När man skall skriva mycket under en längre tid är sittställningen viktig. För
-att inte bli trött skall man försöka inta en avslappnad sittställning och låta
+När man ska skriva mycket under en längre tid är sittställningen viktig. För
+att inte bli trött ska man försöka inta en avslappnad sittställning och låta
 hela underarmen vila mot bordet. Använd papper med stora rutor och en bra
 kulspetspenna. Skriv gärna på varannan rad så att det finns plats under att
 rätta texten.
@@ -172,10 +172,10 @@ bokstaven I.
 
 Var noga med handstilen från början och jobba hela tiden med att förbättra den.
 En olämpligt inlärd handstil är mycket svår att arbeta bort och då får man
-problem vid högre hastigheter. Du skall ju själv kunna tyda din text i
-efterhand, men viktigast är att provförrättaren också skall kunna läsa den.
+problem vid högre hastigheter. Du ska ju själv kunna tyda din text i
+efterhand, men viktigast är att provförrättaren också ska kunna läsa den.
 
-Inlärningstexter är ofta uppdelade i grupper med 5 eller 4 tecken. Dessa skall
+Inlärningstexter är ofta uppdelade i grupper med 5 eller 4 tecken. Dessa ska
 simulera ord. Var noga med att du får tydliga ordmellanrum även på papperet.
 
 \section{Eftersläpning vid mottagning}
@@ -193,8 +193,8 @@ handen!
 
 \section{Sändningsövningar}
 
-Att telegrafera är att uttrycka sig. De handsända morsetecknen skall vara
-tydliga, på samma sätt som att tal och vanlig handskrift skall vara det. Det är
+Att telegrafera är att uttrycka sig. De handsända morsetecknen ska vara
+tydliga, på samma sätt som att tal och vanlig handskrift ska vara det. Det är
 därför mycket viktigt att teckengivningen lärs in på rätt sätt. Speciellt de
 första sändningsövningarna bör ske tillsammans med en kunnig instruktör. Om
 instruktör saknas --- följ då noga anvisningarna och var självkritisk!
@@ -254,14 +254,14 @@ olämpligt högt bord. Detta medför en olämplig och tröttande arbetsställnin
 Bild \ref{fig:bild_morse_5}.
 
 Håll löst omkring nyckelknoppen med tummen och långfingret. Pekfingrets
-undersida skall vila lätt ovanpå knoppen. Använd alltid denna
+undersida ska vila lätt ovanpå knoppen. Använd alltid denna
 trefingerfattning. Håll nyckelknoppen ganska långt in på fingrarna. När man
 senare vill öka takten kan man flytta ut fattningen mot fingerspetsarna.
 
 Morsetecknen skapas med rytmiska handledssvängningar uppåt/nedåt. Håll inte hårt
 om knoppen --- men släpp den inte heller --- och spänn inte handleden. Handleden
-skall svänga mellan ett något upplyft och ett vågrätt läge. I det vågräta läget
-når nyckeln sitt s.k. kontaktläge. För att nästa tecken skall hinnas med i tid,
+ska svänga mellan ett något upplyft och ett vågrätt läge. I det vågräta läget
+når nyckeln sitt s.k. kontaktläge. För att nästa tecken ska hinnas med i tid,
 får handleden inte svänga djupare än till det vågräta läget.
 
 \section{Styrd sändning}
@@ -275,7 +275,7 @@ generator som avger en konstant ton.
 En textutskrift används som förlaga för den egna sändningen. Det gäller att
 lyssna på morsetecknen från datorn eller bandet, samtidigt läsa samma tecken
 från utskriften och själv sända dessa med nyckeln. Ljudbilden från en egna
-sändningen skall då sammanfalla med den från förebilden. På så sätt samövas
+sändningen ska då sammanfalla med den från förebilden. På så sätt samövas
 hand- och armmusklerna, synen och hörseln för rätt teckengivning.
 
 I SSA:s kurser på ljudband och data finns rytmiska ramsor för övning av styrd
@@ -285,15 +285,15 @@ behöver öva mera.
 
 Styrd sändning övas utan spärrning. Teckenhastigheten och trafikhastigheten ska
 då vara lika. Trafikhastigheten bör åtminstone vara 35 till45 tecken/minut för
-attteckenrytmen skall bli bra. Träna mycket på siffror i den styrda
+attteckenrytmen ska bli bra. Träna mycket på siffror i den styrda
 sändningen. Det ger färdighet vid övergångarna mellal korta och långa
 teckendelar i tecknen. Även mellan vissa morsetecken kan övergångarna vara
 svåra.
 
 \section{Fri sändning}
 
-Först skall styrd sändning av ramsor och tecken klaras utan problem. Börja först
-därefter med fri sändning utan ljudförebild. Normalt skall sändning göras utan
+Först ska styrd sändning av ramsor och tecken klaras utan problem. Börja först
+därefter med fri sändning utan ljudförebild. Normalt ska sändning göras utan
 spärrning.
 
 Försök komma ihåg teckenrytmen från den styrda sändningen. Siffror och
@@ -336,9 +336,9 @@ SETTINGS SHOULD BE ADJUSTED AS INDICATED ON PAGE 3-4, DATED 7/10 1994. QRT + @
 
 \section{Beräkning av antalet teckenvärden}
 
-Vid beräkning av antalet teckenvärden i en telegramtext skall bokstäver (utom Å)
+Vid beräkning av antalet teckenvärden i en telegramtext ska bokstäver (utom Å)
 räknas som ett (1) teckenvärde. Siffror, skiljetecken, felsändningstecken samt
-bokstaven Å skall räknas som två (2) teckenvärden.
+bokstaven Å ska räknas som två (2) teckenvärden.
 
 I ovanstående exempel på provtext är fördelningen av teckenvärdena följande:
 
@@ -350,7 +350,7 @@ Summa teckenvärden &   &         &     & = & 277
 \end{tabular}
 
 Observera, att lystrings-, slut- och avslutningstecken samt felsända avsnitt med
-respektive felsändningstecken också skall ingå i summan av teckenvärden.
+respektive felsändningstecken också ska ingå i summan av teckenvärden.
 
 Den därefter beräknade takten är den s. k. telegram- eller trafikhastigheten.
 

--- a/matte.tex
+++ b/matte.tex
@@ -18,7 +18,7 @@ på båda sidor om likhetstecknet.  Exempel:
 \(\times\).  Då undviks förväxlingar med bokstaven \(x\) i ekvationer, där
 okända tal betecknas med bokstäver).
 
-För att resultatet skall bli rätt måste givna regler alltid följas vid
+För att resultatet ska bli rätt måste givna regler alltid följas vid
 behandlingen av storheterna i uppställningarna. Vid multiplikation och addition
 kan storheterna hanteras i godtycklig ordning, men däremot inte vid division och
 subtraktion.
@@ -173,7 +173,7 @@ Endast en obekant storhet har behandlats i föregående exempel och en ekvation
 har varit tillräcklig för det.
 
 Två eller flera obekanta storheter kan inte behandlas med bara en ekvation.
-Antag, att vi skall beräkna
+Antag, att vi ska beräkna
 
 \[7x+6y=34\]
 
@@ -318,7 +318,7 @@ På samma sätt kan vi skriva
 \end{align*}
 
 
-\(10^6\) anger att 10 skall multipliceras med sig självt 6 gånger, d.v.s.
+\(10^6\) anger att 10 ska multipliceras med sig självt 6 gånger, d.v.s.
 resultatet är 1 miljon.
 
 \(10^{-6}\) anger på samma sätt i miljondel.
@@ -344,7 +344,7 @@ a^n &= a^3 = a \cdot a \cdot a \\
 a \cdot a = a^2
 \end{align*}
 
-\begin{quote}\emph{När potenser med samma bas skall divideras med varandra, fås
+\begin{quote}\emph{När potenser med samma bas ska divideras med varandra, fås
 resultatet genom att den gemensamma basen ``upphöjs till'' skillnaden mellan
 exponenterna.}\end{quote}
 
@@ -366,10 +366,10 @@ T.ex. \(10^0 = 1\) ingår i serien \(10^{-1}\), \(10^0\), \(10^1\), \(10^2\)
 \(\ldots\), vilket
 är ett annat sätt att skriva 0,1; 1; 10; 100 \(\ldots\) etc.
 
-Uttrycket \(a \cdot b^n\) betyder att \(a\) skall multipliceras med \(b\) upphöjt
+Uttrycket \(a \cdot b^n\) betyder att \(a\) ska multipliceras med \(b\) upphöjt
 till \(n\)''.
 
-Uttrycket \((a \cdot b)^n\) betyder att \(a\) och \(b\) skall multipliceras med
+Uttrycket \((a \cdot b)^n\) betyder att \(a\) och \(b\) ska multipliceras med
 varandra \(n\) gånger:
 \[
 (a \cdot b)^n = (a \cdot b) \cdot (a \cdot b) \ldots
@@ -426,7 +426,7 @@ Tidigare behandlade vi uttrycket \(x^2 = 900\) för att få fram värdet på \(x
 ``drog kvadratroten ur 900''.
 Tecknet \(\sqrt{\ \ \ \ }\) kallas rottecken.
 
-\(x = \sqrt{900}\) skall egentligen skrivas \(\sqrt[2]{900}\),
+\(x = \sqrt{900}\) ska egentligen skrivas \(\sqrt[2]{900}\),
 men tvåan brukar uteslutas när det gäller kvadratroten. I övriga fall är det
 nödvändigt att skriva ut rottermen, t. ex. \(\sqrt[3]{100}\) (uttalas
 som 3:e roten ur) eller \(\sqrt[6]{100}\) (uttalas som 6:e roten ur).
@@ -481,8 +481,8 @@ användbarhet vid behandling av godtyckliga
 taluppställningar. Begreppet logaritm är däremot mera användbart.
 
 \begin{quote}\emph{
-Med logaritmen för ett tal menas den exponent, som basen skall upphöjas till,
-för att potensens värde skall bli talet.
+Med logaritmen för ett tal menas den exponent, som basen ska upphöjas till,
+för att potensens värde ska bli talet.
 }\end{quote}
 
 Exempel
@@ -492,7 +492,7 @@ logaritmsystem, vars bas är 2.
 Detta skrivs \(x= log_2 31\) och läses x = tvålogaritmen för talet 31.
 
 Kvadraten på talet 10 är 100, d.v.s. \(10^2 = 100\). Talet 2 är alltså den
-exponent som talet 10 skall upphöjas med för att digniteten skall bli 100.
+exponent som talet 10 ska upphöjas med för att digniteten ska bli 100.
 Således \(\log_{10}{100} = 2\).
 
 Vid omvandling mellan decimala tal och deras logaritmer används s.k.
@@ -500,16 +500,16 @@ logaritmtabeller eller miniräknare (inte de allra enklaste). För
 överslagsberäkningar används även diagram och skalor (t. ex. räknestickan).
 
 Så här räknar man med logaritmer:
-När decimala tal skall \emph{multipliceras} med varandra, omvandlar man dem
+När decimala tal ska \emph{multipliceras} med varandra, omvandlar man dem
 först till logaritmer. Man \emph{adderar} dessa och återvandlar resultatet till
 decimala tal igen.
 
-När decimala tal skall \emph{divideras} med varandra, omvandlar man dem först
+När decimala tal ska \emph{divideras} med varandra, omvandlar man dem först
 till logaritmer. Man \emph{subtraherar} dessa och återvandlar resultatet till
 decimala tal igen.
 
 Exempel
-Talen 100, 100, 100,2 och 2 skall multipliceras med varandra.
+Talen 100, 100, 100,2 och 2 ska multipliceras med varandra.
 Det decimala förfarandet är:
 
 \(100 \cdot 100 \cdot 100 \cdot 2 \cdot 2 = 4000000 = 4 \cdot 10^6\)


### PR DESCRIPTION
Idag bör man använda "ska" framför "skall" då den senare uppfattas som ålderdomlig.