### PR TITLE
Rätta SSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **KonCEPT för Radioamatörcertifikat** är en bok
 ursprungligen skriven av Lennart Wiberg och utgiven av 
-[Sveriges SändareAmatörer](http://ssa.se) (SSA) i syfte att utbilda nya
+[Sveriges Sändareamatörer](http://ssa.se) (SSA) i syfte att utbilda nya
 radioamatörer. Den första upplagan är skriven 1997 och behöver
 därför en uppdatering och tryckas i en ny upplaga. Detta projekt,
 SSA Akademin, är bland annat till för digitalisering och uppdatering

--- a/foreword.tex
+++ b/foreword.tex
@@ -55,7 +55,7 @@ nationell förening i The International Amateur Radio Union (IARU), Region 1.
 
 De nationella föreningarna inom IARU samarbetar över nationsgränserna. Ett
 exempel är när DARC (Deutscher Amateur-RadioClub e. V.) för några år sedan
-ställde sina Ausbildungsunterlagen till SSAs förfogande som källmaterial för
+ställde sina Ausbildungsunterlagen till SSA:s förfogande som källmaterial för
 boken El-lära och Radioteknik. Detta material har till stor del kunnat utnyttjas
 även i här föreliggande bok.
 
@@ -65,7 +65,7 @@ boken El-lära och Radioteknik. Detta material har till stor del kunnat utnyttja
 Förord andra upplagan:
 
 Under 2016 kom en grupp att sammankallas i en vilja att modernisera
-utbildningen av radioamatörer. Denna grupp består av SSAs utbildningsansvariga
+utbildningen av radioamatörer. Denna grupp består av SSA:s utbildningsansvariga
 Jonas Hulten SM5PHU, samt Magnus Danielson SA0MAD, Hans Insulander SM0UTY,
 Petter Karkea SA2PKA samt Peter Lundberg SA2BLV. Utöver denna kärngrupp har
 ett antal andra bidragit i stort och smått.

--- a/koncept/chapter11-5.tex
+++ b/koncept/chapter11-5.tex
@@ -124,7 +124,7 @@ amatörklubbar & SI & + distriktssiffra + bokstäver (specialtillstånd) \\
 amatörklubbar & SJ & + distriktssiffra + bokstäver (specialtillstånd) \\
 amatörklubbar & 7S & + distriktssiffra + bokstäver (specialtillstånd) \\
 amatörklubbar & 8S & + distriktssiffra + bokstäver (specialtillstånd) \\
-%\multicolumn{3}{l}{SSA-tillstånd inom SSAs utbildningsverksamhet} \\
+%\multicolumn{3}{l}{SSA-tillstånd inom SSA:s utbildningsverksamhet} \\
 %& SH & + distriktssiffra + bokstäver (AAA- CZZ). \\
 \end{tabular}
 

--- a/koncept/chapter7-3.tex
+++ b/koncept/chapter7-3.tex
@@ -227,7 +227,7 @@ förvarningar.
   \label{fig:bildII7-9}
 \end{figure}
 
-Bild II 7-9 visar en radioprognos ur SSAs medlemstidning QTC. Ny
+Bild II 7-9 visar en radioprognos ur SSA:s medlemstidning QTC. Ny
 prognos presenteras periodiskt och behandlar
 kortvågsspektrum. Observera det låga solfläckstalet SSN (Sun Spot
 Number) på denna bild.

--- a/koncept/morse.tex
+++ b/koncept/morse.tex
@@ -118,7 +118,7 @@ till 4 nya tecken varje vecka.
 SSA:s telegraferingskurser på band och datadiskett har denna inlärningsordning.
 Det finns dock kurser med annan uppläggning.
 
-\hilight{TODO: Kolla upp status på SSAs ``kurser på band och datadiskett''.}
+\hilight{TODO: Kolla upp status på SSA:s ``kurser på band och datadiskett''.}
 
 \section{Inlärningstid}
 

--- a/matterep.tex
+++ b/matterep.tex
@@ -5,7 +5,7 @@
 \begin{document}
 
 \title{Grundläggande matematik för radioamatörer}
-\author{Föreningen Sveriges Sändaramatörer}
+\author{Föreningen Sveriges Sändareamatörer}
 
 \maketitle
 


### PR DESCRIPTION
Rätta utskrivningen av Sveriges Sändareamatörer samt genitiv-s på förkortningen.