### PR TITLE
Fixa intervallangivelser

### DIFF
--- a/koncept/chapter3-6.tex
+++ b/koncept/chapter3-6.tex
@@ -348,5 +348,5 @@ avläsningsnoggrannhet.
 
 Bandspridning kan också ordnas med två seriekopplade kondensatorer,
 varav den större görs variabel. Typiskt värde på vridkondensatorn i en
-kortvågsutrustning är då 100-500~pF och den fasta kondensatorn mycket
+kortvågsutrustning är då 100--500~pF och den fasta kondensatorn mycket
 mindre än så.

--- a/koncept/chapter3-7.tex
+++ b/koncept/chapter3-7.tex
@@ -253,7 +253,7 @@ Bild \ref{fig:BildII3-81}
 Signalen \(f_1\) från en VCO alstrar en sändningsfrekvens i bandet
 144-146 MHz. Denna blandas med signalen \(f_2\) (136 MHz), som är en
 multiplicerad XO-frekvens. Blandningsprodukten \(f_1 - f_2\) filtreras
-fram, d.v.s. en signal i området 8-10~MHz som påförs en fasjämförare.
+fram, d.v.s. en signal i området 8--10~MHz som påförs en fasjämförare.
 Utsignalen från en VFO, som är variabel inom samma frekvensområde 8-10
 MHz, påförs också fasjämföraren.
 

--- a/koncept/chapter3-8.tex
+++ b/koncept/chapter3-8.tex
@@ -244,7 +244,7 @@ Bild \ref{fig:BildII3-88}
 I ett tidigare avsnitt har vi beskrivit en s.k.  super-VFO. Vi ska
 nu undersöka vilka blandningsprodukter som uppstår i en sådan. De två
 mest uppenbara frekvenserna är blandningsprodukterna (summan) i
-området 144-146~MHz och (skillnaden) i området 128-126~MHz.
+området 144--146~MHz och (skillnaden) i området 128--126~MHz.
 
 Ut från blandaren finner vi ingångsfrekvensen 136~MHz och dess
 övertoner 272~MHz, 408~MHz o.s.v. såväl som VFO-signalen och dess
@@ -269,7 +269,7 @@ sätt:
 
 %%
 
-Eftersom det här handlar om 15:e - 18:e övertonerna, så blir
+Eftersom det här handlar om 15:e -- 18:e övertonerna, så blir
 amplituderna så små, att vi kan bortse från dem.
 
 Det är viktigt med goda filter i signalbehandlande funktionssteg. En

--- a/koncept/chapter4-2.tex
+++ b/koncept/chapter4-2.tex
@@ -298,7 +298,7 @@ Bild \ref{fig:bildII4-12}
 
 I exemplet i förra stycket blev problemet med en störande ton löst med
 ett bandpassfilter med annan frekvensgång.  Men vilka frekvenser kan
-tas emot genom ett lågpassfilter, 0-3000~Hz, om VFO-frekvensen är
+tas emot genom ett lågpassfilter, 0--3000~Hz, om VFO-frekvensen är
 t.ex. 1829,2~kHz?
 
 

--- a/koncept/chapter4-3.tex
+++ b/koncept/chapter4-3.tex
@@ -43,12 +43,12 @@ hjälp av elektromekaniska resonatorer.
 
 Exempel: En sändning på frekvensen 3600~kHz ska tas emot. Vi ställer
 då in VFO-frekvensen till 4055~kHz, eftersom mellanfrekvensen är
-\(4055 - 3600 = 455\) kHz. Den mottagna signalen hamnar då mitt i
+\(4055--3600 = 455\) kHz. Den mottagna signalen hamnar då mitt i
 MF-filtrets passband.
 
 Signaler på angränsande frekvenser tas också emot och alstrar
 blandningsprodukter.  Med ett mellanfrekvensfilter med t.ex. 3~kHz
-bandbredd (453,5-456,5 kHz), kan signalfrekvenser mellan 3598,5 och
+bandbredd (453,5--456,5 kHz), kan signalfrekvenser mellan 3598,5 och
 3601,5 kHz passera genom filtret. En signal med en närliggande
 frekvens t.ex. 3603~kHz, och blandad med den inställda VFO-frekvensen
 4055~kHz, kommer att alstra en skillnadsfrekvens av 452~kHz. Denna
@@ -116,7 +116,7 @@ Ett så högt Q-värde kan endast erhållas med kristallfilter.
 
 För högre mottagningsfrekvenser räcker det, på grund av
 filterproblematiken, oftast inte med en dubbel frekvensomvandling, Om
-man antar en dubbelsuper-mottagare för VHF-området 144-146~MHz enligt
+man antar en dubbelsuper-mottagare för VHF-området 144--146~MHz enligt
 bilden, så skulle en i :a MF med frekvensen 10,7~MHz inte vara
 tillräckligt hög. Vid en mottagningsfrekvens av 146~MHz är nämligen
 spegelfrekvensen \(146 + (2 \cdot 10,7) = 167.4\)~MHz, alltså endast

--- a/koncept/chapter4-3.tex
+++ b/koncept/chapter4-3.tex
@@ -43,7 +43,7 @@ hjälp av elektromekaniska resonatorer.
 
 Exempel: En sändning på frekvensen 3600~kHz ska tas emot. Vi ställer
 då in VFO-frekvensen till 4055~kHz, eftersom mellanfrekvensen är
-\(4055--3600 = 455\) kHz. Den mottagna signalen hamnar då mitt i
+\(4055 - 3600 = 455\) kHz. Den mottagna signalen hamnar då mitt i
 MF-filtrets passband.
 
 Signaler på angränsande frekvenser tas också emot och alstrar

--- a/koncept/chapter4-9.tex
+++ b/koncept/chapter4-9.tex
@@ -171,7 +171,7 @@ Bild \ref{fig:bildII4-27}
 
 Mellanfrekvensfiltret för SSB-mottagning ska endast släppa igenom
 ett av de två sidbanden, vars bredd är skillnaden mellan högsta och
-lägsta överförda LF-frekvens.  Inom amatörradio är detta 3~kHz - 0,3~kHz
+lägsta överförda LF-frekvens.  Inom amatörradio är detta 3~kHz -- 0,3~kHz
 = 2,7~kHz, alltså något mindre än hälften av bandbredden vid AM.
 
 Ett alltför brett MF-filter skulle också släppa igenom oönskade

--- a/koncept/chapter5-1.tex
+++ b/koncept/chapter5-1.tex
@@ -145,7 +145,7 @@ En VFO är mest stabil på låga frekvenser medan en CO har god
 stabilitet även på högre frekvenser. När signalerna från dessa
 blandas, bildas blandningsprodukter som är skillnaden och summan av
 signalernas frekvenser. Bilden visar en telegrafisändare där detta
-fenomen används för sändning inom området 14,0 - 14,5 eller 3,5 - 4,0
+fenomen används för sändning inom området 14,0--14,5 eller 3,5--4,0
 beroende på passbandet i filtret efter blandaren.
 
 Resultatet är en superheterodyn-VFO med både variabel och stabil
@@ -179,9 +179,9 @@ släpps fram. Det ena sidbandet undertrycks med ett
 bandpassfilter. Denna SSB-signal flyttas till avsett frekvensband
 genom ännu en frekvensblandning och ytterligare filtrering.
 
-I exemplet är CO-frekvensen 9~MHz. VFO har frekvensområdet 5,0 - 5,5
+I exemplet är CO-frekvensen 9~MHz. VFO har frekvensområdet 5,0--5,5
 MHz. Vid blandningen fås blandningsprodukter inom frekvensområdena
-14,0 - 14,5 och 4,0 - 3,5~MHz. Genom att välja bandpassfilter kan man
+14,0--14,5 och 4,0--3,5~MHz. Genom att välja bandpassfilter kan man
 sända i ett av dessa frekvensområden.  Efterföljande driv- och
 slutsteg utförs för att arbeta i detta frekvensband, antingen utan
 särskild avstämning - s.k. bredbandigt utförande - eller genom
@@ -221,7 +221,7 @@ styras av en PLL. I det andra fallet (bild \ref{fig:bildII5-6}) kan frekvensen i
 någon av oscillatorerna styras av en PLL.  En närmare beskrivning av
 PLL-styrning av dessa två sändarkoncept följer här.
 
-\subsubsection{PLL-styrd FM-sändare för 144 - 146~MHz}
+\subsubsection{PLL-styrd FM-sändare för 144--146~MHz}
 \textbf{
 HAREC a.\ref{HAREC.a.5.2.3}\label{myHAREC.a.5.2.3}
 }
@@ -240,8 +240,8 @@ oscillator) och ett PA (effektförstärkare).
 VCO ingår som det frekvensstyrda elementet i en PLL. Utfrekvensen från
 VCO (ärvärdet) avläses och delas periodiskt med talet 10 och matas in
 i en programmerbar frekvensdelare. Eftersom frekvensområdet för VCO är
-144 - 146~MHz, kommer infrekvensen till den programmerbara delaren att
-ligga i området 14,4 - 14,6~MHz. Delningstalet i denna delare kan
+144--146~MHz, kommer infrekvensen till den programmerbara delaren att
+ligga i området 14,4--14,6~MHz. Delningstalet i denna delare kan
 programmeras in i steg om 1 mellan talen 5760 och 5840.
 
 Med den första delarens divisor 10 och den andra delarens divisor
@@ -299,8 +299,8 @@ blandaren.
 Summafrekvensen 70~MHz filtreras fram som mellanfrekvens. Den önskade
 sändningsfrekvensen fås genom att blanda 70~MHz MF med frekvensen från
 VCO och därefter filtrera fram skillnadsfrekvensen.  VCO i detta
-exempel täcker frekvensområdet 40 - 69,5~MHz. Således blir sändarens
-täckningsområde 1,5 - 30~MHz. För att filterfunktionen ska bli
+exempel täcker frekvensområdet 40--69,5~MHz. Således blir sändarens
+täckningsområde 1,5--30~MHz. För att filterfunktionen ska bli
 optimal, kan den delas upp på flera valbara filtersektioner, t.ex. ett
 per amatörband. Valet kan ske automatiskt och styrt av frekvensläget
 på VCO.

--- a/koncept/chapter5-2.tex
+++ b/koncept/chapter5-2.tex
@@ -69,7 +69,7 @@ mycket enkel.
 Bild \ref{fig:bildII5-12}
 
 Bilden visar en kristallstyrd FM-sändare med frekvensomkopplare för
-kanalval inom 144 - 146 MHz-bandet.
+kanalval inom 144--146 MHz-bandet.
 
 En kristallfrekvens av c:a 12~MHz multipliceras 12 gånger i en kedja
 av förstärkarsteg för att ge sändningsfrekvensen. Bilden visar
@@ -193,9 +193,9 @@ bandomkopplare. Samtidigt kopplas ett bandpassfilter in efter
 blandaren i super-VFO, som svarar till det aktuella frekvensbandet.
 
 För t.ex. 21 MHz-bandet är VFO-filtrets passband 12 - 12,5~MHz. När en
-VFO-signal 12 - 12,5~MHz blandas med en 9 MHz SSB modulerad signal
+VFO-signal 12--12,5~MHz blandas med en 9 MHz SSB modulerad signal
 erhålls en frekvens i området 3 - 3,5~MHz och en frekvens i området
-21 - 21,5~MHz. Den önskade av dessa frekvenser filtreras fram med
+21--21,5~MHz. Den önskade av dessa frekvenser filtreras fram med
 omkopplingsbara bandpassfilter, vilket sker med den bandkopplare som
 nämnts tidigare.
 

--- a/koncept/chapter6-1.tex
+++ b/koncept/chapter6-1.tex
@@ -242,8 +242,8 @@ erhålls en matningsimpedans av 50 Ω, vilket passar bra för en
 koaxialkabel med 50 Ω impedans.
 
 \emph{Yagi- och Quad-antenner:} En anpassningsanordning för anslutning
-av 50 - 60 Ω koaxialkabel ingår oftast i fabriksgjorda
-riktantenner. En 50 - 60 Ω koaxialkabel kan då användas direkt.
+av 50--60 Ω koaxialkabel ingår oftast i fabriksgjorda
+riktantenner. En 50--60 Ω koaxialkabel kan då användas direkt.
 
 \subsubsection{Reaktansen i en icke-resonant antenn}
 \textbf{
@@ -328,7 +328,7 @@ Ett sändarslutsteg med elektronrör är vanligen utrustat med en
 vid HF-utgången. Syftet är att kunna anpassa
 sändarens utgångsimpedans till impedansen i antennledningen. I moderna
 sändare består denna anordning mycket ofta av ett s.k. π-filter, vars
-utgångsimpedans kan variera mellan c:a 30-150 Ω.
+utgångsimpedans kan variera mellan c:a 30--150 Ω.
 
 Ett transistoriserat slutsteg är oftast utfört för en fast
 utgångsimpedans av 50 Ω och är alltså i behov av en

--- a/koncept/chapter6-3.tex
+++ b/koncept/chapter6-3.tex
@@ -46,7 +46,7 @@ sammankopplade i ändarna. Mittpunkten på ett av elementen är ansluten
 till antennledningen.
 
 Matningsimpedansen för en omvikt \(\lambda/2\)-dipol med två element är
-c:a fyra gånger högre än den för en enkel dipol, d.v.s. 200 - 300
+c:a fyra gånger högre än den för en enkel dipol, d.v.s. 200--300
 Ω. Den omvikta dipolen, som endast fungerar på grundfrekvensen och på
 dess udda övertoner, är relativt bredbandig. Matningsimpedansen kan
 ändras med sinsemellan olika diametrar på de ingående elementen samt

--- a/koncept/chapter6-6.tex
+++ b/koncept/chapter6-6.tex
@@ -176,7 +176,7 @@ v = \frac{1}{\sqrt{\varepsilon}} = \frac{1}{\sqrt{2.25}} = \frac{1}{1,5} = 0,666
 
 1 meter av en sådan koaxialkabel är \(1/0,666 = 1,333\) meter för en
 HF-signal.  Även bandkablar har naturligtvis en hastighetsfaktor,
-vanligen 0,7 - 0,85.
+vanligen 0,7--0,85.
 
 \subsection{Karaktäristisk impedans Z i ledningar}
 \textbf{

--- a/koncept/chapter7-3.tex
+++ b/koncept/chapter7-3.tex
@@ -5,7 +5,7 @@ HAREC a.\ref{HAREC.a.7.3}\label{myHAREC.a.7.3}
 
 Jonosfären har fått namnet från begreppet jon, som är en fri elektron
 eller annan laddad partikel. Jonisering- elektrisk uppladdning av
-jordatmosfären sker mellan c:a 40 - 400 km över jordytan. Där är
+jordatmosfären sker mellan c:a 40--400 km över jordytan. Där är
 lufttrycket tillräckligt lågt för att joner ska kunna röra sig fritt
 under avsevärd tid utan att kollidera och återförena sig till neutrala
 atomer.
@@ -25,9 +25,9 @@ antal joniserade skikt kan definieras.  Se Bild \ref{fig:bildII7-7}.
 \subsection{D-skiktet}
 
 D-skiktet förekommer under den ljusa delen av dygnet på en höjd av c:a
-50 - 90 km. På 70 - 90 km höjd orsakas joniseringen huvudsakligen av
+50--90 km. På 70--90 km höjd orsakas joniseringen huvudsakligen av
 röntgenstrålar från solen, medan den kosmiska strålningen har störst
-påverkan på 50-70 km höjd. D-skiktet dämpar de infallande
+påverkan på 50--70 km höjd. D-skiktet dämpar de infallande
 radiovågorna, med största verkan i kortvågsområdets lågfrekventa del
 och under de ljusaste timmarna under sommaren.  D-skiktet har dålig
 reflexionsförmåga och verkar hindrande på långdistansförbindelser.
@@ -35,7 +35,7 @@ reflexionsförmåga och verkar hindrande på långdistansförbindelser.
 \subsection{E-skiktet}
 
 E-skiktet (Kenelly-Heaviside-skiktet) är det lägsta reflekterande
-jonosfärskiktet Det förekommer på en höjd av c:a 90-140 km och är mest
+jonosfärskiktet Det förekommer på en höjd av c:a 90--140 km och är mest
 koncentrerat på c:a 110 km höjd. E-skiktet alstras av att ultraviolett
 strålning joniserar syreatomer. Skiktet reflekterar vågor bäst i
 kortvågsområdets lågfrekventa del och är kraftigast under den ljusa
@@ -73,8 +73,8 @@ förbindelser kan uppnås.
 \subsection{F-skiktet}
 
 F-skiktet är det högst liggande jonosfärskiktet. Det förekommer såväl
-dag- som nattetid på en höjd av 140 - 500~km. Den nedre del av skiktet,
-140 - 200 km, uppvisar andra variationer än den övre delen. F-skiktet
+dag- som nattetid på en höjd av 140--500~km. Den nedre del av skiktet,
+140--200 km, uppvisar andra variationer än den övre delen. F-skiktet
 beskrivs därför som två skikt, \(\mathrm{F_1}\) upp till ca 200 km
 höjd och \(\mathrm{F_2}\) över denna höjd.
 
@@ -87,13 +87,13 @@ sommaren. Under natten förenar sig \(\mathrm{F_1}\)- och
 \(\mathrm{F_2}\)-skiktet är det skikt som varierar mest i tiden och
 rummet. Den högsta joniseringsgraden inträffar vanligen sent efter
 högsta lokala solstånd, ibland under aftontimmarna.  Skiktets maximala
-jonisering är på 250 - 350 km höjd på mellanlatituder och på 350 - 500
+jonisering är på 250--350 km höjd på mellanlatituder och på 350--500
 km höjd vid ekvatorn. På mellanlatituder ligger den största
 elektrontätheten i skiktet högre under natten än under dagen. Vid
 ekvatorn är förhållandet omvänt.
 
 Reflexioner i \(\mathrm{F_2}\)-skiktet möjliggör att stora
-avstånd kan överbryggas (1 hopp = 3000 - 4000~km).
+avstånd kan överbryggas (1 hopp = 3000--4000~km).
 
 \begin{figure}
   \includegraphics[width=\textwidth]{images/bild_2_7-08}
@@ -127,10 +127,10 @@ kallas den \emph{kritiska frekvensen}, som varierar med
 joniseringsgraden i atmosfären. Den kritiska frekvensen är högst vid
 högt solfläckstal, såväl i E- som i F-skikten, eftersom
 joniseringsgraden då är störst. Den kritiska frekvensen för E-skiktet
-varierar mellan c:a 1 - 4~MHz beroende på tidpunkt i solfläckscykeln
+varierar mellan c:a 1--4~MHz beroende på tidpunkt i solfläckscykeln
 och tid på dagen. Den kritiska frekvensen för F-skiktet varierar med
 tid på dagen, årstid och skede i solfläckscykeln.  Den kan variera
-från 2 - 3~MHz natten under ett solfläcksminimum till 12 - 13~MHz på
+från 2--3~MHz natten under ett solfläcksminimum till 12--13~MHz på
 dagen under ett solfläcksmaximum.
 
 \subsection{Kritisk vinkel}

--- a/koncept/chapter7-6.tex
+++ b/koncept/chapter7-6.tex
@@ -1,17 +1,17 @@
 \section{Vågutbredning på VHF, UHF, SHF och EHF}
 
 \subsection{Allmänt}
-Frekvensområdet 30 - 300000 MHz delas upp
+Frekvensområdet 30--300000 MHz delas upp
 i följande mindre avsnitt som kallas \\
-VHF (Very High Frequency, 30-300 MHz), \\
-UHF (Ultra High Frequency, 300-3000 MHz), \\
-SHF (Super High Frequency, 3-30 GHz) och \\
-EHF (Extra High Frequency, 30-300 GHz). \\
+VHF (Very High Frequency, 30--300 MHz), \\
+UHF (Ultra High Frequency, 300--3000 MHz), \\
+SHF (Super High Frequency, 3--30 GHz) och \\
+EHF (Extra High Frequency, 30--300 GHz). \\
 
 På VHF och högre frekvenser (tidigare UKV) förekommer sällan någon
 vågutbredning via jonosfären annat än under tiden för maximal sol
 aktivitet. I stället utnyttjas den lägre delen av atmosfären och
-knappast högre än 4 - 5 km över jordytan. Denna del av atmosfären
+knappast högre än 4--5 km över jordytan. Denna del av atmosfären
 kallas för troposfär och vågutbredningen därför för troposfärisk
 vågutbredning.
 
@@ -57,7 +57,7 @@ en s.k. temperaturinversion.
 Vågor på VHF och UHF bryts då mot gränsskiktet och böjs av mot
 jordytan. Om det finns två inversionsskikt samtidigt, så kan de bilda
 en slags vågledare, s.k. dukt (eng. duct = ledning). En räckvidd på
-600 - 1300 km kan uppnås. Denna typ av vågutbredning förekommer ofta
+600--1300 km kan uppnås. Denna typ av vågutbredning förekommer ofta
 vid högt atmosfärstryck under sommaren.
 
 \subsection{Reflexion mot \(\mathrm{E_s}\) (sporadiskt E)}
@@ -70,7 +70,7 @@ gasmoln på en höjd av c:a 120 km och med en oregelbunden fördelning.
 
 Den kritiska frekvensen är hög för \(\mathrm{E_s}\)-skiktet och det
 kan även reflektera vågor på VHF och UHF så effektivt att avstånd av
-1000 - 4000 km kan överbryggas.
+1000--4000 km kan överbryggas.
 
 \subsection{Aurora-reflexion}
 \textbf{
@@ -103,7 +103,7 @@ meteorgrus som faller in i jordatmosfären. Detta fenomen kan utnyttjas
 för radioförbindelser.
 
 Joniseringen sker när partiklarna passerar genom E-skiktet och brinner
-upp. Eftersom joniseringen har en varaktighet av endast 0,1 - 10
+upp. Eftersom joniseringen har en varaktighet av endast 0,1--10
 sekunder måste \emph{MS-förbindelser} planeras och förberedas
 väl. Förbindelserna begränsas vanligen till utbyte av anropssignaler
 och signalrapporter med höghastighetstelegrafi med en hastighet av 300
@@ -163,7 +163,7 @@ frekvensband. Detta kallas numera att de har olika konfiguration.
 
 En vanlig konfiguration av transponder är CONFIG-V/U (f.d. MOD-J) där
 upplänken är på VHF-bandet, t ex. 145,900-146,000 MHz och nerlänken på
-UHF-bandet t. ex.  435,800-435,900 MHz. Varje upplänk-frekvens
+UHF-bandet t. ex.  435,800--435,900 MHz. Varje upplänk-frekvens
 motsvarar en bestämd nerlänk-frekvens, t. ex. upp 145,950 och ner
 435,850 MHz. Trafiken övertranspondern kan därför ske i full duplex.
 

--- a/koncept/chapter9-3.tex
+++ b/koncept/chapter9-3.tex
@@ -79,7 +79,7 @@ bildstörningar vid mottagning av digital-TV.
 
 Störningar i TV som orsakas av sändare på lägre frekvenser kan i många fall
 avhjälpas med frekvensfilter. Det kan t. ex. uppstå TV-störningar, när en amatörradiostation sänder på 21~MHz-bandet. Dess 3:e överton hamnar då på
-TV-kanal E-4 (61 - 68~MHz). Problem med störningar av den här typen har minskat
+TV-kanal E-4 (61--68~MHz). Problem med störningar av den här typen har minskat
 betydligt sedan digital-TV infördes och de flesta TV-sändningar numera sker på
 VHF- och UHF-banden.
 
@@ -89,11 +89,11 @@ igenom signaler under c:a 35~MHz.
 Ett högpassfilter före en TV-mottagare kan t.ex. dimensioneras att endast släppa
 igenom signaler med frekvenser över c:a 35~MHz.
 
-Om inte mottagning i TV-band I (40- 68 MHz) är av intresse, så kan ett
+Om inte mottagning i TV-band I (40--68 MHz) är av intresse, så kan ett
 högpassfilter med en gränsfrekvens av ca 160~MHz sättas in. Det dämpar d
 oönskad utstrålning från sändare i KV- och VHF-området, d.v.s. upp
-t.o.m. 144-146~MHz amatörband. Däremot släpps TV-band III (174- 230MHz) och
-TV-banden IV och V igenom (470 - 890 MHZ).
+t.o.m. 144--146~MHz amatörband. Däremot släpps TV-band III (174--230MHz) och
+TV-banden IV och V igenom (470--890 MHZ).
 
 Ytterligare avstörningsmedel kan sättas in om det uppstår störningar av
 amatörradiosändningar. Det kan vara skärmströmsfilter på antennkablar,

--- a/koncept/chapter9-4.tex
+++ b/koncept/chapter9-4.tex
@@ -144,11 +144,11 @@ Exempel på kommersiella spärrfilter är SF~145-S för 144~MHz och
 SF~435-S, för 435~MHz amatörband. De är avsedda att kopplas in före
 mottagare som störs av amatörradiosändningar.
 
-SF 145-S spärrar amatörbandet 144 - 148~MHz och släpper igenom banden
-0 - 120 och 174 - 870~MHz.
+SF 145-S spärrar amatörbandet 144--148~MHz och släpper igenom banden
+0--120 och 174--870~MHz.
 
-SF 435-S spärrar amatörbandet 430 - 440~MHz och släpper igenom 0 -
-350 och 470 - 870~MHz.
+SF 435-S spärrar amatörbandet 430--440~MHz och släpper igenom
+0--350 och 470--870~MHz.
 
 \subsection{Nät- och skärmströmfilter för mottagning}
 \index{gemensam överföring}


### PR DESCRIPTION
Gör så att många angivelser av intervall följer rekommendationen: inga mellanslag och (kort) tankstreck som avdelare.