### PR TITLE
Rätta URL:er

### DIFF
--- a/koncept/chapter10-1.tex
+++ b/koncept/chapter10-1.tex
@@ -37,11 +37,11 @@ AED, i närheten bör den användas så skyndsamt som möjligt.
 \textbf{Glöm inte att ringa efter hjälp. Ring 112.}
 
 Broschyren \emph{Vägledning vid elskada} kan laddas ner eller beställas från
-Elsäkerhetsverkets hemsida \url{www.elsakerhetsverket.se}.
+Elsäkerhetsverkets hemsida \url{http://www.elsakerhetsverket.se}.
 
-Vårdguidens hemsida \url{www.1177.se} har instruktioner för hjärt- och lungräddning, HLR.
+Vårdguidens hemsida \url{https://www.1177.se} har instruktioner för hjärt- och lungräddning, HLR.
 
-Svenska rådet för Hjärt- och Lungräddning \url{www.HLR.nu} har beskrivningar
+Svenska rådet för Hjärt- och Lungräddning \url{http://www.hlr.nu} har beskrivningar
 och instruktionsfilmer för hjärt- och lungräddning.
 
 \subsection{Resistansen genom människokroppen}


### PR DESCRIPTION
Rätta att icke-kompletta URL:er var uppmärkta som URL:er. Därmed gick de inte att klicka på i den genererade PDF:en.