### PR TITLE
Lägg till hårt mellanslag innan procenttecken

### DIFF
--- a/koncept/appendix-e.tex
+++ b/koncept/appendix-e.tex
@@ -90,8 +90,8 @@ I andra modulationssystem än för amplitudmodulation kan däremot bredden på
 sidbanden mycket överstiga den högsta frekvenskomposanten i basbandssignalen.
 
 \emph{Använd bandbredd} \emph{eng. occupied bandwidth} är avståndet mellan
-översta och nedersta delen av ett spektrum, där medeleffekten är lägre än 0.5\%
 (-23 dB) av den totala medeleffekten. För amatörer är det inte alltid lätt att
+översta och nedersta delen av ett spektrum, där medeleffekten är lägre än 0.5~\%
 bestämma den använda bandbredden. Den kan mätas med en spektrumanalysator, men
 ett sådant instrument är svårtillgänglig för de flesta amatörer. Den använda
 bandbredden kan även beräknas, men det kräver matematikkunskaper i

--- a/koncept/chapter1-8.tex
+++ b/koncept/chapter1-8.tex
@@ -259,7 +259,7 @@ Om de modulerande LF-frekvenserna är mellan 0,3 och 3~kHz, så blir sändningen
 totala bandbredd 6~kHz.
 
 LF-signalernas amplitud påverkar sidbandens och sidofrekvensernas amplitud. Vid
-maximal modulation (100 \% modulationsgrad) varierar signalamplituden mellan
+maximal modulation (100~\% modulationsgrad) varierar signalamplituden mellan
 noll och dubbla värdet av det för en omodulerad bärvåg.
 
 Som mest kan vardera sidbandet överföra en fjärdedel så mycket effekt som
@@ -537,7 +537,7 @@ modulerande frekvensen \(f_{LF}\). Amplitudfördelningen mellan sidofrekvenserna
 står i förhållande till deviationen, varvid deras amplitud blir mindre desto
 längre bort från bärvågen de är.
 
-I praktiken anses en sidofrekvens försumbar när dess amplitud är mindre än 1 \%
+I praktiken anses en sidofrekvens försumbar när dess amplitud är mindre än 1~\%
 av amplituden för omodulerad bärvåg.
 
 För beräkning av bandbredden används begreppet modulationsindex m, vilket är
@@ -1082,11 +1082,11 @@ amplitud hos bruset. Detta kan uttryckas i form av den matematiska funktionen
 \emph{error function (erf)}.
 
 När gränsen är 1 sigma, dvs. 1 gånger RMS-värdet för brus-amplituden, från
-medelvärdet så är 67 \% sannolikhet att värdet är i inom gränsvärdet, dvs. en
-bitfelssannolikhet på 33 \%.
-Ligger det inom 2 sigma, så har sannolikheten ökat till 97 \%, en
-bitfelssannolikhet på 3 \% och vid 3 sigma är den 99,7\% med en
-bitfelssannolikhet på ringa 0,3 \%, vilket ofta används för många
+medelvärdet så är 67~\% sannolikhet att värdet är i inom gränsvärdet, dvs. en
+bitfelssannolikhet på 33~\%.
+Ligger det inom 2 sigma, så har sannolikheten ökat till 97~\%, en
+bitfelssannolikhet på 3~\% och vid 3 sigma är den 99,7~\% med en
+bitfelssannolikhet på ringa 0,3~\%, vilket ofta används för många
 ingenjörsapplikationer. Dock, för överföring av information har vi högre krav.
 För en bitfelssannolikhet på \(10^{-12}\), ofta benämnt BER på 1E-12, så
 behövs det 14 sigma bort till gränsen, dvs. brusmängden får max vara 1/14 av

--- a/koncept/chapter2-3.tex
+++ b/koncept/chapter2-3.tex
@@ -248,7 +248,7 @@ och ökar i stället vid ytan. Ju högre frekvensen är, desto större är
 strömtätheten vid ytan. Fenomenet kallas yteffekt (på engelska
 \emph{skin effect}) och uppträder i alla ledare.
 
-Det djup i ledarmaterialet där laddningstätheten sjunkit till 37\% av
+Det djup i ledarmaterialet där laddningstätheten sjunkit till 37~\% av
 värdet vid ytan kallas \emph{skin depth}. För koppar är detta djup c:a 70~mm vid
 100~Hz. Vid 1~MHz har djupet minskat till 0,07~mm och vid 100~MHz till
 0,0067~mm. På grund av yteffekten är alltså materialet i mitten av homogena

--- a/koncept/chapter3-1.tex
+++ b/koncept/chapter3-1.tex
@@ -415,8 +415,8 @@ som kallas tidskonstant:
 \end{gather*}
 
 Efter tiden \(t = 1\tau\) från inkopplingsögonblicket har spänningen över
-kondensatorn ökat från noll till 63\% av maxvärdet. Efter tiden \(t = 5\tau\)
-är kondensatorn uppladdad till 99\%.
+kondensatorn ökat från noll till 63~\% av maxvärdet. Efter tiden \(t = 5\tau\)
+är kondensatorn uppladdad till 99~\%.
 
 \emph{Strömmen} från kondensatorn minskar exponentiellt under uppladdningen.
 
@@ -428,9 +428,9 @@ kondensatorn ökat från noll till 63\% av maxvärdet. Efter tiden \(t = 5\tau\)
 \end{tabular}
 
 Efter tiden \(t = 1\tau\) från inkopplingsögonblicket har strömmen till
-kondensatorn minskat till 37\% av maxvärdet.
+kondensatorn minskat till 37~\% av maxvärdet.
 
-Efter tiden \(t = 5\tau\) återstår 1\% av strömmens maxvärde.
+Efter tiden \(t = 5\tau\) återstår 1~\% av strömmens maxvärde.
 
 \subsubsection{Urladdning}
 
@@ -453,10 +453,10 @@ Strömriktningen är motsatt den vid uppladdningen.
 
 \[i_c = - I_{max} \cdot e^{-\frac{t}{\tau}}\]
 
-Efter tiden \(t = 1\tau\) är kondensatorn urladdad så, att 37\% av \(I_{max}\)
+Efter tiden \(t = 1\tau\) är kondensatorn urladdad så, att 37~\% av \(I_{max}\)
 respektive \(U_{max}\) återstår.
 
-Efter tiden \(t = 5\tau\) är kondensatorn urladdad så, att mindre än 1\% av
+Efter tiden \(t = 5\tau\) är kondensatorn urladdad så, att mindre än 1~\% av
 \(I_{max}\) respektive \(U_{max}\) återstår.
 
 Exempel på beräkning av tidskonstanten:
@@ -518,8 +518,8 @@ s\ [\text{sek}] \quad
 \]
 
 Efter en tid av \(t = 1\tau\) från inkopplingsögonblicket har strömmen genom
-induktorn ökat från noll till 63\% av \(I_{max}\) och motspänningen över
-induktorn minskat till 37\% av maxvärdet.
+induktorn ökat från noll till 63~\% av \(I_{max}\) och motspänningen över
+induktorn minskat till 37~\% av maxvärdet.
 
 \emph{Urkoppling}
 
@@ -538,7 +538,7 @@ urkopplingstillfället \(I_{max} = i_L\) och minskar därefter exponentiellt.
 \end{tabular}
 
 Efter en tid av \(t = 1\tau\) från urkopplingsögonblicket har strömmen genom
-induktorn minskat till 37\% av maxvärdet.
+induktorn minskat till 37~\% av maxvärdet.
 
 Teoretiskt kan spänningarna och strömmarna aldrig nå ett noll- eller maxvärde,
 men för praktiskt bruk anses detta inträffa efter en tid av minst \(5\tau\).
@@ -1147,6 +1147,6 @@ Bild \ref{fig:BildII3-21}
 Bilden visar med en kurva vilket impedansvärde kretsen har vid olika frekvenser.
 Impedansens högsta värde är vid frekvensen \(f_{res}\) och avtar vid frekvenser
 som är högre eller lägre. Vid frekvenserna \(f_1\) och \(f_2\) är
-impedansvärdet t.ex. 70\% av maximalvärdet. Med bandbredden \(b\) förstås
+impedansvärdet t.ex. 70~\% av maximalvärdet. Med bandbredden \(b\) förstås
 skillnaden mellan impedansvärdena i ett sådant frekvenspar, d.v.s.
 \(b = f_2 - f_1\).

--- a/koncept/chapter3-4.tex
+++ b/koncept/chapter3-4.tex
@@ -221,7 +221,7 @@ Klass A är ett arbetssätt i linjära LF- och HF-förstärkarsteg, t.ex. i
 mottagare samt AM- och SSB-modulerade sändare. Vilovärdet på strömmen
 i huvudkretsen, den s.k. arbetspunkten, placeras i mitten på den
 rakaste delen av styrkaraktäristikan (\(I=0,5\cdot I_{max}\)).  Därmed
-fås låg distorsion. Verkningsgraden är upp till 50\%.
+fås låg distorsion. Verkningsgraden är upp till 50~\%.
 
 \subsubsection{Klass AB}
 \index{klass AB}
@@ -247,7 +247,7 @@ Bild \ref{fig:BildII3-45}
 Klass B är ett olinjärt arbetssätt med en låg viloström i förhållande
 till \(I_{max}\) d.v.s. arbetspunkten ligger i nederkant av
 styrkaraktäristikans nedre krökta del. Verkningsgraden är upp till
-67\%. Trots det används klass B i linjära LF-och H F-förstärkarsteg
+67~\%. Trots det används klass B i linjära LF-och H F-förstärkarsteg
 t.ex. i SSB-sändare.
 
 Om klass B skulle tillämpas i ett slutsteg med endast ett rör eller en
@@ -274,7 +274,7 @@ AM-sändare. Arbetssättet är kraftigt olinjärt. Viloströmmen är noll,
 d.v.s. arbetspunkten ligger på den negativa delen av
 styrkaraktäristikan. Endast toppen av den ena halvvågen av insignalen
 återges och i starkt förvrängd form. Verkningsgraden är upp till
-80\%. Övertonerna dämpas av svängningskretsen. En resonanskrets med
+80~\%. Övertonerna dämpas av svängningskretsen. En resonanskrets med
 högt Q-värde behövs som utgångskrets varvid amplituddistorsion inte
 framstår som besvärande vid CW och FM. Med hjälp av en utgångskrets
 kan frekvensmultiplicering utföras med förstärkare i klass C.  (På

--- a/koncept/chapter3-9.tex
+++ b/koncept/chapter3-9.tex
@@ -55,9 +55,9 @@ Bilden visar ett sändarslutsteg med en triod.  I serie med
 tilledningen för anodspänningen finns sekundärlindningen av en
 modulationstransformator för LF-signalen.
 
-Den LF-förstärkare som driver transformatorn måste för 100\%
+Den LF-förstärkare som driver transformatorn måste för 100~\%
 modulationsgrad kunna avge bärvågens halva effekt. Eftersom uteffekten
-från en fullt utmodulerad A3E-sändare är 150\% av den i vila, måste
+från en fullt utmodulerad A3E-sändare är 150~\% av den i vila, måste
 slutsteget dimensioneras därefter. Utöver den egna signalspänningen
 måste modulationstransformatorn även klara slutstegets arbetsspänning.
 

--- a/koncept/chapter4-9.tex
+++ b/koncept/chapter4-9.tex
@@ -113,7 +113,7 @@ Bild \ref{fig:bildII4-25}
 Bilden visar hur när- och förselektion kompletterar varandra i ett
 frekvensspektrum.  Märk, att passbandbredden \(b\) i
 förselektionskretsen anger avståndet mellan de frekvenser där
-signalamplituden dämpats till 70\% av toppvärdet. I exemplet här ovan
+signalamplituden dämpats till 70~\% av toppvärdet. I exemplet här ovan
 har antagits att förkretsen för kortvågsmottagning har samma Q-värde
 som förkretsen för mellanvågsmottagning.
 

--- a/koncept/chapter6-1.tex
+++ b/koncept/chapter6-1.tex
@@ -80,14 +80,14 @@ elektriska egenskaper beroende på antennens mekaniska utförande,
 påverkan från jordplan och omgivning m.m.
 
 Ett förhållande mellan längd och tjocklek av 10000 ger t.ex. en c:a
-2\% mekaniskt kortare antenn. Förhållandet 30 ger en c:a 5\% kortare
+2~\% mekaniskt kortare antenn. Förhållandet 30 ger en c:a 5~\% kortare
 antenn. Det första värdet kan passa för en 2~mm tjock halvvågsantenn
 för 7~MHz. Det andra värdet för en 3,5 mm tjock halvvågsantenn för 145
 MHz. Diagram för den s.k. förkortningsfaktorn finns i de flesta
 antennhandböcker.
 
 I följande formel har den mekaniska längden (\(l_m\)) för en fritt upphängd
-trådantenn valts 2\% kortare än den elektriska längden.
+trådantenn valts 2~\% kortare än den elektriska längden.
 
 \[l_m = \frac{c}{2f} \cdot 0,98 = \frac{147\cdot 10^6}{f} \quad \text{[m]}\]
 

--- a/koncept/chapter7-3.tex
+++ b/koncept/chapter7-3.tex
@@ -180,7 +180,7 @@ Rekommenderad övre frekvensgräns för en tillförlitlig radioförbindelse
 kallas \emph{optimal traffic frequency} - FOT - och väljs något under
 MUF som marginal för oregelbundenheter och turbulens i jonosfären,
 liksom för korttidsavvikelser från det förutsagda månatliga
-medianvärdet för MUF. FOT är vaniigen ungefär 15\% lägre än MUF.
+medianvärdet för MUF. FOT är vaniigen ungefär 15~\% lägre än MUF.
 
 \subsection{Lägsta användbara frekvens (LUF)}
 

--- a/koncept/chapter8-1.tex
+++ b/koncept/chapter8-1.tex
@@ -99,7 +99,7 @@ och dels med likriktare även för växelströmsmätning.
 
 Vridspoleinstrument med likriktare används ofta för frekvenser upp
 till c:a 10~kHz och strömmar ner till 0.1~mA. Noggrannheten är sällan
-bättre än 1.5\% av fullt utslag.
+bättre än 1.5~\% av fullt utslag.
 
 Beroende på funktionsprincipen kan det skilja på hur instrument mäter,
 vilket nödvändigtvis inte är detsamma som hur mätvärdet presenteras.
@@ -334,7 +334,7 @@ med en s.k. dip-meter. Även mer exakta metoder finns.
 Mätinstrument indelas i noggrannhetsklasser efter största tillåtna
 felvisning. Klasserna är 0.1, 0.2, 0.5, 1.0, i .5, 2.5 och 5.0 varvid
 klassen anges på instrumentet. Som exempel får ett instrument i klass
-2.5 ha ett tillåtet mätfel av \(\pm\)2.5\% av fullt utslag.
+2.5 ha ett tillåtet mätfel av \(\pm\)2.5~\% av fullt utslag.
 
 Mätresultatet bestäms av flera faktorer; dels av instrumentets
 s.k.mätonoggrannhet, dels av hur mätvärdet presenteras och slutligen

--- a/koncept/chapter8-2.tex
+++ b/koncept/chapter8-2.tex
@@ -301,7 +301,7 @@ utbytbara induktorer för olika frekvensområden.  Den används för att
 bestämma resonansfrekvensen på passiva och aktiva svängningskretsar
 samt vid bestämning av induktanser och kapacitanser.
 
-Noggrannheten är c:a 3\%.
+Noggrannheten är c:a 3~\%.
 
 Funktion: Instrumentet avger alternativt reagerar för en HF-signal med
 viss frekvens.  Resonansfrekvensen i dip-meterns svängningskrets är


### PR DESCRIPTION
Innan procenttecken har man ett (hårt) mellanslag.