### PR TITLE
Lägg till Japan som 60 Hz:are

### DIFF
--- a/koncept/chapter1-6.tex
+++ b/koncept/chapter1-6.tex
@@ -176,7 +176,7 @@ I formler betecknas frekvensen med \(f\).
 
 Nätfrekvensen för elkraft är i Europa 50~Hz.
 
-Andra nätfrekvenser förekommer, t.ex. 60~Hz i USA.
+Andra nätfrekvenser förekommer, t.ex. 60~Hz i USA och Japan.
 
 Frekvensområdet vid överföring av kvalitativt tal och musik, lågfrekvens LF, är
 mellan ca 16~Hz och 16~kHz.


### PR DESCRIPTION
Med tanke på hur stor del av radioapparaterna som tillverkats av Japanska företag kan det vara allmänbildning att veta att (halva) Japan använder 60 Hz i elnätet.