### PR TITLE
Fixed some layout problems with images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,9 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# Finished output
+koncept-larobok.pdf
+koncept-refbok.pdf
+koncept.pdf
+matterep.pdf

--- a/koncept/chapter1-1.tex
+++ b/koncept/chapter1-1.tex
@@ -486,19 +486,23 @@ Exempel:
 \subsection{Formelsnurran}
 \textbf{FÖRDJUPNING}
 
-\begin{wrapfigure}{R}{0.5\textwidth}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}{R}{0.3\textwidth}
   \includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_1-04.pdf}
   \caption{''Formelsnurra'' för Ohms och Joules lagar}
   \label{fig:BildII1-4}
-%  \vspace{-100pt}
-\end{wrapfigure}
+  %  \vspace{-100pt}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
-Bild \ref{fig:BildII1-4}
-
-Så här finner man rätt formel i ''snurran'':
+Så här finner man rätt formel i ''snurran'' (bild \ref{fig:BildII1-4}):
 Välj ett segment med önskad storhet \(I\), \(U\), \(R\) eller \(P\) som det första
 ledet i formeln. Inom valt segment finns tre alternativ för det andra
 ledet i formeln. Välj det alternativ som innehåller två kända storheter.
+
+Bild \ref{fig:BildII1-4}
 
 Exempel:
 

--- a/koncept/chapter2-2.tex
+++ b/koncept/chapter2-2.tex
@@ -197,7 +197,7 @@ består då oftast av luft, men kan även vara ett fast material.
 
 \subsubsection{Fasta kondensatorer}
 
-\begin{figure}
+\begin{figure}[h]
 \includegraphics[width=\textwidth]{images/cropped_pdfs/bild_2_2-02.pdf}
 \caption{Schemasymboler för kondensatorer}
 \label{fig:BildII2-2}

--- a/koncept/chapter2-7.tex
+++ b/koncept/chapter2-7.tex
@@ -124,11 +124,15 @@ Bild \ref{fig:BildII2-29}
 \index{trioden}
 \index{elektronrör!triod}
 
-\begin{wrapfigure}[9]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_2-30.pdf}
-\caption{Symboler för triod och pentod}
-\label{fig:BildII2-30}
-\end{wrapfigure}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}[9]{R}{0.5\textwidth}
+  \includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_2-30.pdf}
+  \caption{Symboler för triod och pentod}
+  \label{fig:BildII2-30}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
 Bild \ref{fig:BildII2-30}
 

--- a/koncept/chapter3-1.tex
+++ b/koncept/chapter3-1.tex
@@ -178,11 +178,15 @@ det är fråga om en växelströmskrets.
 \index{kondensatorer!parallellkopplade}
 \index{parallellkoppling!kondensatorer}
 
-\begin{wrapfigure}[18]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-05.pdf}
-\caption{Parallellkopplade kondensatorer}
-\label{fig:BildII3-05}
-\end{wrapfigure}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}[18]{R}{0.5\textwidth}
+  \includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-05.pdf}
+  \caption{Parallellkopplade kondensatorer}
+  \label{fig:BildII3-05}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
 Bild \ref{fig:BildII3-05}
 
@@ -215,11 +219,15 @@ Räkneexempel:
 \index{kondensatorer!seriekopplade}
 \index{seriekoppling!kondensatorer}
 
-\begin{wrapfigure}[10]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-06.pdf}
-\caption{Seriekopplade kondensatorer}
-\label{fig:BildII3-06}
-\end{wrapfigure}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}[10]{R}{0.5\textwidth}
+  \includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-06.pdf}
+  \caption{Seriekopplade kondensatorer}
+  \label{fig:BildII3-06}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
 Bild \ref{fig:BildII3-06}
 
@@ -954,11 +962,15 @@ rakt neråt (vektorerna roterar motsols). Spänningen över reaktansen \(X_L\)
 \index{oscillator}
 \index{oscillator!Thomson svängningskrets}
 
-\begin{wrapfigure}[30]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-17.pdf}
-\caption{Thomsons svängningskrets}
-\label{fig:BildII3-17}
-\end{wrapfigure}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}[30]{R}{0.5\textwidth}
+  \includegraphics[width=0.4\textwidth]{images/cropped_pdfs/bild_2_3-17.pdf}
+  \caption{Thomsons svängningskrets}
+  \label{fig:BildII3-17}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
 Bild \ref{fig:BildII3-17}
 
@@ -1024,11 +1036,15 @@ kretsdata: Induktans 200~µH, kapacitans 200~pF, förlustresistans 10~Ω.
 \index{parallellresonans}
 \index{resonans!parallellkrets}
 
-\begin{wrapfigure}[25]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-18.pdf}
-\caption{Resonansfallet i parallellkrets}
-\label{fig:BildII3-18}
-\end{wrapfigure}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}[25]{R}{0.5\textwidth}
+  \includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-18.pdf}
+  \caption{Resonansfallet i parallellkrets}
+  \label{fig:BildII3-18}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
 Parallellkretsen består i sig själv av seriekopplade komponenter, varav
 \(X_L\) och \(X_C\) är reaktiva. Vid resonans är dessa lika stora och
@@ -1071,11 +1087,15 @@ Z = \frac{X_L \cdot X_C}{r_L} = \frac{L}{r_L \cdot C}
 \index{serieresonans}
 \index{resonans!seriekrets}
 
-\begin{wrapfigure}[20]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-19.pdf}
-\caption{Resonansfallet i seriekrets}
-\label{fig:BildII3-19}
-\end{wrapfigure}
+\begin{figure*}[h]
+\begin{center}
+  %%\begin{wrapfigure}[20]{R}{0.5\textwidth}
+  \includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-19.pdf}
+  \caption{Resonansfallet i seriekrets}
+  \label{fig:BildII3-19}
+  %%\end{wrapfigure}
+\end{center}
+\end{figure*}
 
 Bild \ref{fig:BildII3-19}
 

--- a/koncept/chapter3-2.tex
+++ b/koncept/chapter3-2.tex
@@ -338,11 +338,15 @@ avsevärt högre i frekvens.
 \index{cavity filter}
 \index{filter!kavitet}
 
-\begin{wrapfigure}[15]{R}{0.5\textwidth}
-\includegraphics[width=0.5\textwidth]{images/cropped_pdfs/bild_2_3-31.pdf}
-\caption{Kavitetsfilter}
-\label{fig:BildII3-31}
+%%\begin{figure*}[h]
+%%\begin{center}
+\begin{wrapfigure}[15]{R}{0\textwidth}
+  \includegraphics[width=0.2\textwidth]{images/cropped_pdfs/bild_2_3-31.pdf}
+  \caption{Kavitetsfilter}
+  \label{fig:BildII3-31}
 \end{wrapfigure}
+%%\end{center}
+%%\end{figure*}
 
 Bild \ref{fig:BildII3-31}
 


### PR DESCRIPTION
Some of the wrapfigure images was overflowing the text. The detailed layout should be left
to the finishing typesetting, so I converted most of them to normal figure environments.