### PR TITLE
Mer konsekvent formatering av anropsexempel

### DIFF
--- a/koncept/chapter13-5.tex
+++ b/koncept/chapter13-5.tex
@@ -216,10 +216,16 @@ Det behöver inte bli stelt för den skull!
 Allmänt anrop är ett sätt att kalla på någon
 -- vem som helst -- att kommunicera med.
 
-På telegrafi låter det så här: CQ CQ CQ de SM0XYZ K, dvs. anropet
-först och därefter den egna anropssignalen.
+På telegrafi låter det så här:
+
+-- CQ CQ CQ de SM0XYZ K
+
+dvs. anropet först och därefter den egna anropssignalen.
+
 På telefoni låter det så här:
-Allmänt anrop, allmänt anrop, allmänt anrop från SM0XYZ Kom.
+
+-- Allmänt anrop, allmänt anrop, allmänt anrop från SM0XYZ Kom
+
 Glöm inte Kom i slutet!
 
 Riktat anrop gör man, när man vill tala med någon särskild station.
@@ -236,7 +242,7 @@ På telefoni låter det så här:
 
 Motstationen svarar förhoppningsvis på anropet, alltså
 
--- SM0XYZ från SM0ZYX Kom.
+-- SM0XYZ från SM0ZYX Kom
 
 \subsection{Upprättad förbindelse}
 
@@ -250,7 +256,7 @@ sända KN (kom du och ingen annan (nobody else).
 
 Om förbindelsen varar länge, är det lämpligt att upprepa anropssignalerna ungefär var tionde minut vid överlämning.
 
--- SM0ZYX från SM0XYZ Kom.
+-- SM0ZYX från SM0XYZ Kom
 
 \subsection{Avsluta förbindelse}
 


### PR DESCRIPTION
Exempel på allmänt anrop var inbäddat i brödtext medans exempel på riktat  anrop var utbrytet till egna rader för bättre läsbarhet.

Allmänt anrop är nu på egna rader och följer samma formatering som för riktat anrop då jag anser läsbarheten blir bättre.

Har även tagit bort "." (punkt/stopptecken) som förekom i vissa fall efter Kom.
Då texterna syftar till att vara exempel på vad man ska sända (telefoni eller CW) är punkten i sammanhanget missvisande då det inte är avsett att man ska sända/uttala tecknet.

### Innehåll

- Exempel på allmänt anrop på egna rader för bättre läsbarhet
- Tagit bort missvisande "." (punkt/stopptecken) efter "Kom"

### Checklista

- [X] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [X] Språkligt granskad (stavning och grammatik)
- [x] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [X] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [x] Godkänd av två granskare
- [X] Författaren är klar och godkänner merge

### Stänger följande issues

Fixes #328