### PR TITLE
Uppdaterat språk i avsnittet "Binära tal" i kapitlet "Matematik".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ och följer [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Borttaget
 
 ### Ändrat
+- Bytter felaktig användning av ordet "decimal" till "siffra".
+- Förtydligar vad oktal och hexadecimal form är för något.
+- Ändrar till utskrivna siffor istället för siffror.
+- I enlighet med texifiering.md #31
+- Extra radbrytning i enlighet med texifiering.md #5
 
 ## 2.0.0-RC.0 – 2017-09-10
 ### Tillagt

--- a/koncept/matte.tex
+++ b/koncept/matte.tex
@@ -583,7 +583,7 @@ x d.v.s. (\(10^x\)) &          & tal)                  \\ \hline
 
 \emph{Binära tal} är tal som skrivs på talbas 2 istället för vår normala
 talbas 10.
-Det innebär att varje siffra till vänster har en vikt som är 2 gånger större
+Det innebär att varje siffra till vänster har en vikt som är två gånger större
 än föregående.
 Varje siffra kan bara vara 0 eller 1.
 
@@ -601,13 +601,13 @@ Ett enkelt sätt att illustrera det är en kort tabell.
   111 & 4 & 2 & 1 & 7 \\
 \end{tabular}
 
-Ofta grupperar man de binära värdena i grupper om 3 eller 4 siffror
+Ofta grupperar man de binära värdena i grupper om tre eller fyra siffror
 beroende på sammanhanget.
 
 För större värden är binärt ohanterbart långt.
 Därför konverterar man gärna grupperna av värden till siffror och bokstäver,
-där grupper om 3 skrivs på oktal form (talbas 8) och grupper om 4 skrivs på hexadecimal
-form (talbas 16).
+där grupper om tre skrivs på oktal form (talbas 8) och grupper om fyra skrivs på 
+hexadecimal form (talbas 16).
 
 \begin{tabular}{r|rrrr|c|c|r}
   binärt tal & \(2^3\) & \(2^2\) & \(2^1\) & \(2^0\) & Oktal & HEX & decimalt\\ \hline

--- a/koncept/matte.tex
+++ b/koncept/matte.tex
@@ -606,8 +606,8 @@ beroende på sammanhanget.
 
 För större värden är binärt ohanterbart långt.
 Därför konverterar man gärna grupperna av värden till siffror och bokstäver,
-där grupper om 3 skrivs på oktal form och grupper om 4 skrivs på hexadecimal
-form.
+där grupper om 3 skrivs på oktal form (talbas 8) och grupper om 4 skrivs på hexadecimal
+form (talbas 16).
 
 \begin{tabular}{r|rrrr|c|c|r}
   binärt tal & \(2^3\) & \(2^2\) & \(2^1\) & \(2^0\) & Oktal & HEX & decimalt\\ \hline

--- a/koncept/matte.tex
+++ b/koncept/matte.tex
@@ -583,9 +583,9 @@ x d.v.s. (\(10^x\)) &          & tal)                  \\ \hline
 
 \emph{Binära tal} är tal som skrivs på talbas 2 istället för vår normala
 talbas 10.
-Det innebär att varje decimal till vänster har en vikt som är 2 gånger större
+Det innebär att varje siffra till vänster har en vikt som är 2 gånger större
 än föregående.
-Varje decimal kan bara vara 0 eller 1.
+Varje siffra kan bara vara 0 eller 1.
 
 Ett enkelt sätt att illustrera det är en kort tabell.
 
@@ -601,7 +601,7 @@ Ett enkelt sätt att illustrera det är en kort tabell.
   111 & 4 & 2 & 1 & 7 \\
 \end{tabular}
 
-Ofta grupperar man de binära värdena i grupper om 3 eller 4 decimaler
+Ofta grupperar man de binära värdena i grupper om 3 eller 4 siffror
 beroende på sammanhanget.
 
 För större värden är binärt ohanterbart långt.


### PR DESCRIPTION
### Innehåll

- Förändringar

- Bytter felaktig användning av ordet "decimal" till "siffra".
- Förtydligar vad oktal och hexadecimal form är för något.
- Ändrar till utskrivna siffor istället för siffror.
- I enlighet med texifiering.md .31
- Extra radbrytning i enlighet med texifiering.md .5

### Checklista

- [x] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [x] Språkligt granskad (stavning och grammatik)
- [X] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [x] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [x] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge

### Stänger följande issues

Fixes #365
