### PR TITLE
Säg till Travis CI att använda nyare OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
     texlive-fonts-extra \
     texlive-pictures \
     texlive-math-extra \
-    texlive-science \
     texlive-xetex \
     sshpass"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,16 @@ group: travis_latest
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y -qq texlive-full sshpass
+  - "sudo apt-get install -y -qq \
+    texlive \
+    texlive-lang-european \
+    texlive-latex-extra \
+    texlive-fonts-extra \
+    texlive-pictures \
+    texlive-math-extra \
+    texlive-science \
+    texlive-xetex \
+    sshpass"
 
 script:
   - make koncept.pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,7 @@ group: travis_latest
 
 before_install:
   - sudo apt-get -qq update
-  - "sudo apt-get install -y -qq \
-    texlive \
-    texlive-lang-european \
-    texlive-latex-extra \
-    texlive-fonts-extra \
-    texlive-pictures \
-    texlive-math-extra \
-    texlive-xetex \
-    sshpass"
+  - sudo apt-get install -y -qq texlive-full sshpass
 
 script:
   - make koncept.pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+group: travis_latest
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
[Någon gång efter 11 december 2017](https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images) kommer [Ubuntu Xenial](https://wiki.ubuntu.com/XenialXerus/ReleaseNotes) bli tillgänglig som val på [Travis CI](https://travis-ci.org). Jag lägger upp den här PR:n redan nu för att testa hur det kommer funka om vi byter.