### PR TITLE
Språkliga ändringar i Bilaga B, Matematik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ och följer [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Extra radbrytning i enlighet med texifiering.md #5
 - Förtydligande av prefixs syfte.
 - Formel rättad i avsnittet "Exempel med 2 obekanta" i kapitlet "Matematik".
+- Ändrar rubrik till "Ekvation med en obkant" från "Exempel med .."
+- Ändrar 1/2 till en/två i rubrik i Bilaga B, matematik
+- Ändrar förkortningen s.k. till så kallad(e) i Bilaga B, matematik
+
 
 ## 2.0.0-RC.0 – 2017-09-10
 ### Tillagt

--- a/koncept/matte.tex
+++ b/koncept/matte.tex
@@ -100,7 +100,10 @@ nämnarna till täljarna.
 Vid multipliceringen fås samma resultat för var och en av varianterna, vilket
 visar att de är likvärdiga.
 
-\section{Exempel med en obekant}
+\section{Ekvation med en obekant}
+
+Med följande exempel visas några av de metoder man kan använda för att lösa en
+ekvation med en obekant.
 
 Om tredjedelen av ett tal är 8 enheter större än femtedelen av samma tal, vilket
 är då talet?
@@ -177,7 +180,7 @@ om förtecknet byts till det motsatta.
   5x- 3x-120 &= 0 \\
 \end{align*}
 
-\section{Exempel med två obekanta}
+\section{Ekvation med två obekanta}
 
 Endast en obekant storhet har behandlats i föregående exempel och en ekvation
 har varit tillräcklig för det.

--- a/koncept/matte.tex
+++ b/koncept/matte.tex
@@ -100,7 +100,7 @@ nämnarna till täljarna.
 Vid multipliceringen fås samma resultat för var och en av varianterna, vilket
 visar att de är likvärdiga.
 
-\section{Exempel med 1 obekant}
+\section{Exempel med en obekant}
 
 Om tredjedelen av ett tal är 8 enheter större än femtedelen av samma tal, vilket
 är då talet?
@@ -177,7 +177,7 @@ om förtecknet byts till det motsatta.
   5x- 3x-120 &= 0 \\
 \end{align*}
 
-\section{Exempel med 2 obekanta}
+\section{Exempel med två obekanta}
 
 Endast en obekant storhet har behandlats i föregående exempel och en ekvation
 har varit tillräcklig för det.

--- a/koncept/matte.tex
+++ b/koncept/matte.tex
@@ -8,8 +8,8 @@
 Ekvation är ett annat ord för likhet.
 Vid matematiska beräkningar ställs storheterna upp i en eller flera ekvationer.
 
-I en s.k. sann ekvation har resultatet av de uppställda storheterna samma värde
-på båda sidor om likhetstecknet.
+I en så kallad sann ekvation har resultatet av de uppställda storheterna samma
+värde på båda sidor om likhetstecknet.
 
 \textbf{Exempel:}
 
@@ -37,7 +37,7 @@ för \(\dfrac{15}{3}\).
 
 Likaså blir resultatet annorlunda när man skriver \(15 - 5\) i stället för
 \(5 - 15\).
-Vid division kan talen ställas upp som s.k. bråktal.
+Vid division kan talen ställas upp som så kallade bråktal.
 De kan skrivas på något av sätten \(15:3\) eller \(15/3\) eller
 \(\frac{15}{3}\).
 
@@ -94,7 +94,7 @@ b \cdot y \cdot \frac{x}{y} = \frac{a}{b} \cdot b \cdot y \quad \text{d.v.s.}
 \quad b \cdot x = a \cdot y
 \]
 
-Detta visar den s.k. diagonalregeln, som innebär korsvis uppmultiplicering av
+Detta visar den så kallade diagonalregeln, som innebär korsvis uppmultiplicering av
 nämnarna till täljarna.
 
 Vid multipliceringen fås samma resultat för var och en av varianterna, vilket
@@ -509,7 +509,7 @@ Talet 2 är alltså den exponent som talet 10 ska upphöjas med för att dignite
 ska bli 100.
 Således \(\log_{10}{100} = 2\).
 
-Vid omvandling mellan decimala tal och deras logaritmer används s.k.
+Vid omvandling mellan decimala tal och deras logaritmer används så kallade
 logaritmtabeller eller miniräknare (inte de allra enklaste).
 För överslagsberäkningar används även diagram och skalor (t.ex. räknestickan).
 


### PR DESCRIPTION
### Innehåll

- Ändrar rubrik till "Ekvation med en obekant" från "Exempel med .."

Då nya koncept införs i avsnittet blir det väldigt konstigt att använda "Exempel" i rubriken.
Finns dessutom underrubriker med "Exempel" också vilket ger exempel i exempel vilket inte
känns helt motiverat.

Lade till en förklarande text i första att koncepten förklaras genom ett exempel.

Hade ursprungligen rubriken "Lösning av ekvation med en obekant" rubriken blir dock då så
lång att den sväller ut i sidhuvudet.

Mindre ändringar
- Ändrar 1/2 till en/två i rubrik i Bilaga B, matematik
- Ändrar förkortningen s.k. till så kallad(e) i Bilaga B, matematik

### Checklista

- [X] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [X] Språkligt granskad (stavning och grammatik)
- [X] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [X] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [ ] Godkänd av två granskare
- [X] Författaren är klar och godkänner merge

### Stänger följande issues
