### PR TITLE
Saknad referens till ITU-RR appendix ompekad till ITU-RR

### DIFF
--- a/koncept.bib
+++ b/koncept.bib
@@ -53,7 +53,7 @@
   OPTnumber = 	 {},
   OPTaddress = 	 {},
   OPTmonth = 	 {},
-  OPTnote = 	 {},
+  note = 	 {\url{https://www.itu.int/pub/R-REG-RR}},
   OPTannote = 	 {}
 }
 

--- a/koncept/appendix-e.tex
+++ b/koncept/appendix-e.tex
@@ -8,7 +8,7 @@
 \index{tilldelat frekvensband}
 \index{frekvenstolerans}
 
-Radiosändningar beskrivs enligt ITU-RR Appendix 1 \cite{ITU-RR-appendices} med
+Radiosändningar beskrivs enligt ITU-RR~\cite[Appendix 1]{ITU-RR} med
 standardiserade kombinationer av siffror och bokstäver som beskriver
 sändningens nödvändiga bandbredd och sändningsklass.
 

--- a/koncept/chapter13-1.tex
+++ b/koncept/chapter13-1.tex
@@ -31,7 +31,7 @@ HAREC b.\ref{HAREC.b.1.1}\label{myHAREC.b.1.1},
 }
 
 Ibland behöver man göra förtydliganden genom att bokstavera.
-Det internationella finns i ITU radioreglemente (RR) \cite[Appendix 14]{ITU-RR-appendices}
+Det internationella finns i ITU radioreglemente (RR) \cite[Appendix 14]{ITU-RR}
 och kravställs i CEPT för HAREC \cite[Annex 6]{TR6102}.
 
 Svenska radioamatörer ska kunna två fonetiska alfabet, dels det


### PR DESCRIPTION
### Innehåll

- Har lagt till URL i ITU-RR i .bib så den pekar mot ITU websida
- Har ändrat de två referenserna till ITU-RR-Appendices att peka mot ITU-RR istället
- Uppdaterade referensen till ITU-RR appendix 1 att följa samma format som ref till appendix 14 (att inkludera "appendix _" i \cite) (stilregel 25)

### Checklista

- [x] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [x] Språkligt granskad (stavning och grammatik)
- [x] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [x] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [x] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge

### Stänger följande issues

Fixes # `<- följt av issue-nummer`
