### PR TITLE
Bygg i Docker container i Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
+sudo: required
+
 language: generic
 
-before_install:
-  - sudo apt-get -qq update
-  - "sudo apt-get install -y -qq \
-    texlive \
-    texlive-lang-european \
-    texlive-latex-extra \
-    texlive-fonts-extra \
-    texlive-pictures \
-    texlive-math-extra \
-    texlive-xetex \
-    sshpass"
+services:
+  - docker
+
+before_script:
+  - make docker-image
 
 script:
-  - make koncept.pdf
+  - make docker-build
 
 after_success:
   - sha256sum koncept.pdf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM debian:testing
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -y \
-    make \
-    sshpass
-RUN apt-get install -y \
-    texlive \
-    texlive-lang-european \
-    texlive-latex-extra \
-    texlive-pictures \
-    texlive-science-doc \
-    texlive-science
-RUN apt-get install -y \
-    texlive-xetex
+FROM alpine:3.8
+
+RUN apk add --no-cache \
+        make \
+        texlive \
+        texlive-xetex \
+        texmf-dist-fontsextra \
+        texmf-dist-latexextra \
+        texmf-dist-pictures \
+        texmf-dist-science


### PR DESCRIPTION
Detta är ungefär hälften av vad jag pratade om [här](https://github.com/SverigesSandareamatorer/SSA-Akademin/issues/446#issuecomment-423767683).  Dockerfilen bygger nu på Alpine istället för Debian, eftersom Alpine containrar blir mindre och byggs snabbare.  Sedan används den containern för att bygga PDF:en av Travis CI.