### PR TITLE
Dockerfile: lade till paketet sshpass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN apk add --no-cache \
         texmf-dist-fontsextra \
         texmf-dist-latexextra \
         texmf-dist-pictures \
-        texmf-dist-science
+        texmf-dist-science \
+        sshpass


### PR DESCRIPTION
### Innehåll

-  Lade till paketet sshpass på grund av detta fel:
    ```
    sshpass -e scp koncept.pdf ${FTP_USER}@${FTP_SERVER}:${FTP_FOLDER}koncept-pdf/koncept.$(cat VERSION.txt)+b$(printf "%04d" "${TRAVIS_BUILD_NUMBER}").${TRAVIS_COMMIT:0:7}.pdf
    The program 'sshpass' is currently not installed. To run 'sshpass' please ask your administrator to install the package 'sshpass'
    ```