### PR TITLE
Större spelrum för microtype att justera texten

### DIFF
--- a/koncept.tex
+++ b/koncept.tex
@@ -11,7 +11,17 @@
 \usepackage[swedish]{babel}
 % \usepackage{paralist}
 
-\usepackage[activate={true,nocompatibility},final,tracking=true,kerning=true,spacing=true,factor=1100,stretch=10,shrink=10]{microtype}
+\usepackage[
+  activate={true,nocompatibility},
+  final,
+  tracking=true,
+  kerning=false,
+  spacing=false,
+  factor=1000,
+  stretch=40,
+  shrink=20,
+  babel=true
+]{microtype}
 
 \usepackage[a4paper,twoside,twocolumn,inner=2.2cm,outer=1.9cm,columnsep=0.9cm,top=2cm,bottom=2cm]{geometry}
 


### PR DESCRIPTION
### Innehåll

På många sidor är det något ord som inte får plats i spalten. Jag föreslår att vi ger paketet microtype lite större spelrum att justera texten. Efter experimenterande har jag kommit fram till innehållet i den här PR:n men kom gärna med egna förslag och åsikter. I [manualen för microtype](https://ftp.acc.umu.se/mirror/CTAN/macros/latex/contrib/microtype/microtype.pdf) hittar man lite om valen man kan göra.

### Checklista

- [x] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [x] Språkligt granskad (stavning och grammatik)
- [x] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [x] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [ ] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge

### Stänger följande issues

Fixes # `<- följt av issue-nummer`
