### PR TITLE
Aktivera Sponsor-knappen i GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://hamshop.ssa.se/index.php?route=product/product&path=68&product_id=72"]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ["https://hamshop.ssa.se/index.php?route=product/product&path=68&product_id=72"]
+custom: ["https://www.ssa.se/ssa/bli-medlem/"]


### PR DESCRIPTION
[GitHub har funktionen](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository) att visa upp hur man kan stödja ett projekt ekonomiskt. Det bästa sättet att stödja KonCEPT borde vara att bli medlem i SSA.

Ett slumpmässigt exempel på hur det ser ut är [Jekyll](https://github.com/jekyll/jekyll). Se delen ”Sponsor this project” i högerspalten.