### PR TITLE
fixar siunitx varningar

### DIFF
--- a/koncept/appendix-mattenheter.tex
+++ b/koncept/appendix-mattenheter.tex
@@ -22,23 +22,23 @@ används som exempel prefix tillsammans med enheterna \si{\hertz},
   \begin{center}
     \begin{tabular}{|Sllll|}
       \hline
-      1 000 000 000 000 000 000 & \si{\hertz} & = \(1 \cdot 10^{18}\)\,\si{\hertz} & = \SI{1}{\exa\hertz} & (\si{\exa} uttalas exa) \\
-      1 000 000 000 000 000 & \si{\hertz}     & = \(1 \cdot 10^{15}\)\,\si{\hertz} & = \SI{1}{\peta\hertz}& (\si{peta} uttalas peta) \\
-      1 000 000 000 000 & \si{\hertz}         & = \(1 \cdot 10^{12}\)\,\si{\hertz}  & = \SI{1}{\tera\hertz}& (\si{\tera} uttalas tera) \\
-      1 000 000 000  & \si{\watt}             & = \(1 \cdot 10^9\)\,\si{\watt}     & = \SI{1}{\giga\watt} & (\si{\giga} uttalas giga) \\
-      1 000 000  & \si{\watt}                 & = \(1 \cdot 10^6\)\,\si{\watt}              & = \SI{1 }{\mega\watt}& (\si{\mega} uttalas mega) \\
-      1 000  & \si{\watt}                     & = \(1 \cdot 10^3\)\,\si{\watt}   & = \SI{1}{\kilo\watt} & (\si{\kilo} uttalas kilo) \\
-      100 &  & = \(1 \cdot 10^2\)             &      & (\si{\hecto} uttalas hekto) \\
-      10 & & = \(1 \cdot 10^1\) & & (\si{deka} uttalas deka) \\
+%      1 000 000 000 000 000 000 & \si{\hertz} & = \(1 \cdot 10^{18}\)\,\si{\hertz} & = \SI{1}{\exa\hertz} & (\si{\exa\noop} uttalas exa) \\
+%      1 000 000 000 000 000 & \si{\hertz}     & = \(1 \cdot 10^{15}\)\,\si{\hertz} & = \SI{1}{\peta\hertz}& (\si{peta\noop} uttalas peta) \\
+      1 000 000 000 000 & \si{\hertz}         & = \(1 \cdot 10^{12}\)\,\si{\hertz}  & = \SI{1}{\tera\hertz}& (\si{\tera\noop} uttalas tera) \\
+      1 000 000 000  & \si{\watt}             & = \(1 \cdot 10^9\)\,\si{\watt}     & = \SI{1}{\giga\watt} & (\si{\giga\noop} uttalas giga) \\
+      1 000 000  & \si{\watt}                 & = \(1 \cdot 10^6\)\,\si{\watt}              & = \SI{1 }{\mega\watt}& (\si{\mega\noop} uttalas mega) \\
+      1 000  & \si{\watt}                     & = \(1 \cdot 10^3\)\,\si{\watt}   & = \SI{1}{\kilo\watt} & (\si{\kilo\noop} uttalas kilo) \\
+      100 &  & = \(1 \cdot 10^2\)             &      & (\si{\hecto\noop} uttalas hekto) \\
+      10 & & = \(1 \cdot 10^1\) & & (\si{deka\noop} uttalas deka) \\
       1 & \si{\volt} &  = \(1 \cdot 10^0\) V & \SI{1}{\volt} & (\(1 = 10^0\) är grundenhet) \\
-      0,1 & \si{\meter} & = \(1 \cdot 10^{-1}\) & \SI{1}{\deci\meter}    & (\si{\deci} uttalas deci) \\
-      0,01 & \si{\meter} & = \(1 \cdot 10^{-2}\) & \SI{1}{\centi\meter} & (\si{\centi} uttalas centi) \\
-      0,001  & \si{\volt}      & = \(1 \cdot 10^{-3}\)\,\si{\volt}      & = \SI{1}{\milli\volt}      & (\si{\milli} uttalas milli) \\
-      0,000 001 & \si{\volt}      & = \(1 \cdot 10^{-6}\)\,\si{\volt}      & = \SI{1}{\micro\volt}      & (\si{\micro} uttalas mikro) \\
-      0,000 000 001 & \si{\farad}      & = \(1 \cdot 10^{-9}\)\,\si{\farad}& = \SI{1}{\nano\farad}      & (\si{\nano} uttalas nano) \\
-      0,000 000 000 001  & \si{F}      & = \(1 \cdot 10^{-12}\)\,\si{\farad}      & = \SI{1}{\pico\farad}      & (\si{\pico} uttalas piko)\\
-      0,000 000 000 000 001 & \si{\coulomb}      & = \(1 \cdot 10^{-15}\)\,\si{\coulomb}  & = \SI{1}{\femto\coulomb}      & (\si{\femto} uttalas femto)\\
-      0,000 000 000 000 000 001  & \si{\coulomb}      & = \(1 \cdot 10^{-18}\)\,\si{\coulomb}      & = \SI{1}{\atto\coulomb}      & (\si{\atto} uttalas atto) \\
+      0,1 & \si{\meter} & = \(1 \cdot 10^{-1}\) & \SI{1}{\deci\meter}    & (\si{\deci\noop} uttalas deci) \\
+      0,01 & \si{\meter} & = \(1 \cdot 10^{-2}\) & \SI{1}{\centi\meter} & (\si{\centi\noop} uttalas centi) \\
+      0,001  & \si{\volt}      & = \(1 \cdot 10^{-3}\)\,\si{\volt}      & = \SI{1}{\milli\volt}      & (\si{\milli\noop} uttalas milli) \\
+      0,000 001 & \si{\volt}      & = \(1 \cdot 10^{-6}\)\,\si{\volt}      & = \SI{1}{\micro\volt}      & (\si{\micro\noop} uttalas mikro) \\
+      0,000 000 001 & \si{\farad}      & = \(1 \cdot 10^{-9}\)\,\si{\farad}& = \SI{1}{\nano\farad}      & (\si{\nano\noop} uttalas nano) \\
+      0,000 000 000 001  & \si{F}      & = \(1 \cdot 10^{-12}\)\,\si{\farad}      & = \SI{1}{\pico\farad}      & (\si{\pico\noop} uttalas piko)\\
+%      0,000 000 000 000 001 & \si{\coulomb}      & = \(1 \cdot 10^{-15}\)\,\si{\coulomb}  & = \SI{1}{\femto\coulomb}      & (\si{\femto\noop} uttalas femto)\\
+%      0,000 000 000 000 000 001  & \si{\coulomb}      & = \(1 \cdot 10^{-18}\)\,\si{\coulomb}      & = \SI{1}{\atto\coulomb}      & (\si{\atto\noop} uttalas atto) \\
       \hline
     \end{tabular}
   \end{center}

--- a/koncept/common.tex
+++ b/koncept/common.tex
@@ -36,7 +36,7 @@
     output-decimal-marker = {,},
     output-product = \cdot,
     retain-explicit-plus = true,
-    input-product = {*},
+%    input-product = {*},
     product-units = single,
     per-mode = symbol,
     range-units = single,
@@ -44,6 +44,7 @@
     separate-uncertainty=true,
     multi-part-units=single
 }
+\DeclareSIUnit\noop{\relax}
 % % % % % % % % % % % 
 % Detta är nya environments för review. De bör vara relativt självförklarande hur de används.
 % I princip sätter man bara den del av texten som har en viss status mellan\begin{rev-granskat} och \end{rev-granskat} tex.

--- a/koncept/foreword.tex
+++ b/koncept/foreword.tex
@@ -142,22 +142,23 @@ boken, tillvaratagit alla delar från den tidigare upplagan, uppdaterat
 den, skrivit nytt material, gjort om layout, typsatt och arbetat med
 innehållet i olika former.
 
-\section*{Förord till senaste upplagan}
+\section*{Femte tryckningen}
 
-Den upplaga av KonCEPT som ni har framför er har genomgått en
-någorlunda stor uppdatering, kommentarer har inkluderats, fel fixats,
-och vi har försökt att göra texten enklare och bättre att läsa, till exempel
-figurplacering i förhållande till texten.
+Femte tryckningen av KonCEPT har bearbetats för att få ett bättre samspel mellan
+bilders placering i förhållande till texten i syftet att göra texten enklare och
+lättare att läsa.
+Ett antal små fel i formler har justerats och några felstavade ord har rättats.
+Några nya kommentarer och förklaringar av begrepp har lagts till.
 
-Det finns med största sannolikhet fortfarande fel och vi vill
-fortlöpande jobba med att se till att texten är korrekt och också
-inkluderar relevant information, så vi ser mycket gärna att ni
-skickar in förslag, noterar fel, och otydligheter.  Skicka mejl till
-\texttt{hq@ssa.se}.
+Det finns med största sannolikhet fortfarande fel och vi vill fortsätta arbetet
+med att se till att texten är korrekt och inkluderar relevant information.
+Vi vill gärna att ni skickar in förslag på förbättringar, om ni tycker att något
+är otydligt eller uppgifter om fel till oss.
+Skicka mejl till \texttt{hq@ssa.se}.
 
 \medskip
 
-Vi tackar varmt för de mejl vi fått hittils!
+Vi tackar varmt för de mejl vi fått hittills!
 
 \bigskip
 


### PR DESCRIPTION
fixar siunitx varningar och problem med enhetslösa prefix i appendix mattenheter fixar dubbla förord

### Innehåll

- Förändringar

### Checklista

- [ ] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [ ] Språkligt granskad (stavning och grammatik)
- [x] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [ ] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [ ] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge

### Stänger följande issues

Fixes # `<- följt av issue-nummer`
