### PR TITLE
Fixa trasigt bygge och spara rapporter

### DIFF
--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -16,14 +16,12 @@ jobs:
       - name: 'Checka ut'
         uses: actions/checkout@v2
       - name: 'Installera'
-        run: >-
-          sudo apt-get -q install
-          texlive
-          texlive-lang-european
-          texlive-science
-          texlive-fonts-recommended
-          texlive-fonts-extra
-          language-pack-sv
+        run: |
+          sudo apt-get update
+          sudo apt-get -q install texlive \
+            texlive-lang-european texlive-science \
+            texlive-fonts-recommended texlive-fonts-extra \
+            language-pack-sv
       - name: 'Kopiera hash'
         run: echo ${{ github.sha }} | cut -c1-7 > SHA.txt
       - name: 'Bygg'

--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -32,7 +32,7 @@ jobs:
         run: mv koncept.pdf koncept.$(cat VERSION.txt)+b${{ github.run_id }}.$(cat SHA.txt).pdf
       - name: 'Skapa rapporter'
         run: |
-          make images.unlinked
+          make images_unlinked
           make TODOs
       - name: 'Ladda upp artefakt'
         uses: actions/upload-artifact@v2
@@ -45,5 +45,5 @@ jobs:
         with:
           name: rapporter
           path: |
-            images.unlinked
+            images_unlinked.txt
             TODOs

--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -32,9 +32,20 @@ jobs:
         run: sha256sum koncept.pdf
       - name: 'Byt namn'
         run: mv koncept.pdf koncept.$(cat VERSION.txt)+b${{ github.run_id }}.$(cat SHA.txt).pdf
+      - name: 'Skapa rapporter'
+        run: |
+          make images.unlinked
+          make TODOs
       - name: 'Ladda upp artefakt'
         uses: actions/upload-artifact@v2
         with:
           name: koncept-pdf
           path: koncept*.pdf
           retention-days: 31
+      - name: 'Ladda upp rapporter'
+        uses: actions/upload-artifact@v2
+        with:
+          name: rapporter
+          path: |
+            images.unlinked
+            TODOs

--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,7 @@ ac2.pdf
 
 # Temp
 SHA.txt
-images.avail
-images.linked
-images.unlinked
+images_avail.txt
+images_linked.txt
+images_unlinked.txt
 TODOs

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,7 @@ ac2.pdf
 
 # Temp
 SHA.txt
+images.avail
+images.linked
+images.unlinked
+TODOs

--- a/Makefile
+++ b/Makefile
@@ -141,14 +141,14 @@ TODOs:  koncept.tex $(KONCEPT_FILES) koncept.log
 	wc -l TODOs
 
 # Länkade bilder
-images.linked: koncept.tex $(KONCEPT_FILES)
-	grep images *.tex | sed -e s/.*images/images/ | sed -e s/\}// | sort -u > images.linked
+images_linked: koncept.tex $(KONCEPT_FILES)
+	grep images ./**/*.tex | sed -e s/.*images/images/ | sed -e s/\}// | sort -u > images_linked.txt
 
-images.avail:
-	ls images/*.pdf | sed -e s/\.pdf// | sort -u > images.avail
+images_avail:
+	ls images/**/*.pdf | sed -e s/\.pdf// | sort -u > images_avail.txt
 
-images.unlinked: images.avail images.linked
-	diff images.avail images.linked | grep \< | sed -e s/\<\ // > images.unlinked
+images_unlinked: images_avail images_linked
+	diff images_avail.txt images_linked.txt | grep \< | sed -e s/\<\ // > images_unlinked.txt
 
 # Genererade bilder
 images/power1.pdf: images/power1.mac


### PR DESCRIPTION
### Innehåll

- Ett uppdaterings-kommando till autobyggena så att de inte går sönder om filerna ändrats på paketservrarna.
- Det finns rapporter i Makefile som nu används och resultatet sparas som en artefakt.

### Checklista

- [x] Följer stilmallen specificerad i [`CONTRIBUTING.md`](../blob/master/.github/CONTRIBUTING.md)
- [ ] Språkligt granskad (stavning och grammatik)
- [x] ~~Förändringar bygger utan fel lokalt~~
- [x] Förändringar bygger utan fel på byggserver
- [x] Förändringar (om signifikanta) införd i [`CHANGELOG.md`](../blob/master/CHANGELOG.md)
- [ ] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge
