### PR TITLE
Lägg till rapport för rader längre än 80 tecken

### DIFF
--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -41,7 +41,7 @@ jobs:
           make images_linked
           make images_unlinked
           make TODOs
-          make too_long_lines
+          make long_lines
       - name: 'Ladda upp artefakt'
         uses: actions/upload-artifact@v3
         with:
@@ -56,4 +56,4 @@ jobs:
             images_linked.txt
             images_unlinked.txt
             TODOs.txt
-            too_long_lines.txt
+            long_lines.txt

--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -42,6 +42,8 @@ jobs:
           make images_unlinked
           make TODOs
           make long_lines
+          cat long_lines.txt | wc -l >> $COUNT_LONG_LINES
+          echo "Antal kodrader längre än 80 tecken: ${COUNT_LONG_LINES}" >> $GITHUB_STEP_SUMMARY
       - name: 'Ladda upp artefakt'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -41,6 +41,7 @@ jobs:
           make images_linked
           make images_unlinked
           make TODOs
+          make too_long_lines
       - name: 'Ladda upp artefakt'
         uses: actions/upload-artifact@v3
         with:
@@ -55,3 +56,4 @@ jobs:
             images_linked.txt
             images_unlinked.txt
             TODOs.txt
+            too_long_lines.txt

--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -42,8 +42,7 @@ jobs:
           make images_unlinked
           make TODOs
           make long_lines
-          cat long_lines.txt | wc -l >> $COUNT_LONG_LINES
-          echo "Antal kodrader längre än 80 tecken: ${COUNT_LONG_LINES}" >> $GITHUB_STEP_SUMMARY
+          echo "Antal kodrader längre än 80 tecken: $(cat long_lines.txt | wc -l)" >> $GITHUB_STEP_SUMMARY
       - name: 'Ladda upp artefakt'
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -206,4 +206,4 @@ images_available.txt
 images_linked.txt
 images_unlinked.txt
 TODOs.txt
-too_long_lines.txt
+long_lines.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## Windows
 Thumbs.db
 Thumbs.db:encryptable
+[Dd]esktop.ini
 
 ## MacOS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 ## Windows
 Thumbs.db
 Thumbs.db:encryptable
-[Dd]esktop.ini
 
 ## MacOS
 .DS_Store
@@ -206,3 +205,4 @@ images_available.txt
 images_linked.txt
 images_unlinked.txt
 TODOs.txt
+too_long_lines.txt

--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,9 @@ images_available:
 images_unlinked: images_available images_linked
 	diff images_available.txt images_linked.txt | grep \< | sed -e s/\<\ // > images_unlinked.txt
 
-too_long_lines:
-	grep '.\{80\}' **/*.tex > too_long_lines.txt
-	cat too_long_lines.txt | wc -l
+long_lines:
+	grep '.\{80\}' **/*.tex > long_lines.txt
+	cat long_lines.txt | wc -l
 
 # Genererade bilder
 macros/bild_tx_heat.eps: macros/bild_tx_heat.m

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ images_available:
 images_unlinked: images_available images_linked
 	diff images_available.txt images_linked.txt | grep \< | sed -e s/\<\ // > images_unlinked.txt
 
+too_long_lines:
+	grep '.\{80\}' **/*.tex > too_long_lines.txt
+	too_long_lines.txt | wc -l
+
 # Genererade bilder
 macros/bild_tx_heat.eps: macros/bild_tx_heat.m
 	octave macros/bild_tx_heat.m

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ images_unlinked: images_available images_linked
 
 too_long_lines:
 	grep '.\{80\}' **/*.tex > too_long_lines.txt
-	too_long_lines.txt | wc -l
+	cat too_long_lines.txt | wc -l
 
 # Genererade bilder
 macros/bild_tx_heat.eps: macros/bild_tx_heat.m

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,6 @@ images_unlinked: images_available images_linked
 
 long_lines:
 	grep '.\{80\}' **/*.tex > long_lines.txt
-	cat long_lines.txt | wc -l
 
 # Genererade bilder
 macros/bild_tx_heat.eps: macros/bild_tx_heat.m


### PR DESCRIPTION
### Innehåll

Lägger till en ny rapport som visar vilka kodrader som är längre än 80 tecken.

### Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../blob/master/.github/CONTRIBUTING.md)
- [ ] Språkligt granskad (stavning och grammatik)
- [x] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [ ] Förändringar (om signifikanta) införd i [CHANGELOG.md](../blob/master/CHANGELOG.md)
- [ ] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge
