### PR TITLE
Sätt riktningen på fältpilar i circuitikz

### DIFF
--- a/koncept.tex
+++ b/koncept.tex
@@ -133,6 +133,7 @@
 % nätverk. Används till kretsdiagram.
 \usepackage[
 	european,
+	nooldvoltagedirection,
 	cuteinductors,
 	smartlabels
 ]{circuitikz}


### PR DESCRIPTION
## Innehåll
Efter att ha rådfrågat kompetens på området har jag fått rekommendationen att sätta circitikz till att använda fältriktningen `nooldvoltagedirection`. Fix #573

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Förändringar bygger utan fel lokalt
- [x] Förändringar bygger utan fel på byggserver
- [x] Förändringar (om signifikanta) införd i [CHANGELOG.md](../CHANGELOG.md)
- [ ] Godkänd av två granskare
- [x] Författaren är klar och godkänner merge
