### PR TITLE
Märk EPUB-generering som experimentell

### DIFF
--- a/.github/workflows/bygg.yml
+++ b/.github/workflows/bygg.yml
@@ -97,7 +97,7 @@ jobs:
             koncept*.pdf
             koncept.log
   bygg-epub:
-    name: 'Bygg EPUB'
+    name: 'Bygg EPUB (experimentell)'
     continue-on-error: true
     runs-on: ubuntu-22.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ och följer [semantisk versionshantering](https://semver.org/lang/sv/spec/v2.0.0
 
 ## [Osläppt]
 ### Tillagt
-- Nytt byggmål för ebok i EPUB-format.
+- Nytt experimentellt byggmål för ebok i EPUB-format.
 
 ## [2.6.0] – 2023-03-22
 ### Fixat

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo 'Användning:                                                           '
 	@echo '   make all                    kör alla make mål                      '
 	@echo '   make koncept.pdf            bygg PDF av KonCEPT                    '
-	@echo '   make koncept.epub           bygg EPUB av KonCEPT                   '
+	@echo '   make koncept.epub           bygg EPUB av KonCEPT (experimentell)   '
 	@echo '   make clean                  rensa alla byggfiler                   '
 	@echo '   make help                   visa den här informationen             '
 


### PR DESCRIPTION
## Innehåll

Märk EPUB-generering som experimentell då den inte fungerar tillförlitligt än. Relaterad till #55. Fix #648.

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [ ] Bygger utan fel på byggserver
- [x] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare
