### PR TITLE
Fixa typo i ISBN på tryckkort.tex

### DIFF
--- a/koncept/tryckort.tex
+++ b/koncept/tryckort.tex
@@ -9,7 +9,7 @@ Föreningen Sveriges Sändareamatörer\\[2\baselineskip]
 \end{center}
 
 \noindent \textbf{Andra upplagan, sjunde tryckningen}\\
-\noindent ISBN: 987-91-86368-23-4\\
+\noindent ISBN: 978-91-86368-23-4\\
 \noindent Version \revision
 \bigskip
 


### PR DESCRIPTION
Hej! Jag fick precis hem min kopia av koncept och noterade en liten miss på första sidan!

## Innehåll

- Två siffror hade bytt plats på ISBN i koncept, tryckkort.tex

## Checklista

- [ ] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [ ] Bygger utan fel på byggserver
- [ ] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [ ] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare
