### PR TITLE
Fixa ekvationer som stoppar EPUB-genereringen

### DIFF
--- a/koncept/chapter2-7.tex
+++ b/koncept/chapter2-7.tex
@@ -200,9 +200,9 @@ Om man vid konstant anodspänning ändrar gallerförspänningen med värdet
 %% k7per Prototypical solutions for unit explanations.
 \noindent%
 \begin{tabularx}{\linewidth}{@{} *1{>{\hsize=.7\linewidth}X} X@{}}
-\begin{align*}
+\begin{equation*}
 \text{Branthet}\quad S = \dfrac{\Delta I_a}{\Delta U_{g1}} 
-\end{align*}
+\end{equation*}
 &
 \begin{equation*}
 \begin{aligned}
@@ -210,7 +210,7 @@ S\ [mA/V]\\
 \Delta I_a\ [mA]\\
 U_{g1}\ [V]
 \end{aligned}
-\end{equation*}
+\end{equation*}\\
 \end{tabularx}
 %%
 Bild \ssaref{fig:BildII2-34} visar den inre resistansen.
@@ -221,15 +221,15 @@ Om man vid konstant gallerförspänning ändrar anodspänningen med
 %% k7per Prototypical solutions for unit explanations.
 \noindent%
 \begin{tabularx}{\linewidth}{@{} *1{>{\hsize=.7\linewidth}X} X@{}}
-\begin{align*}
+\begin{equation*}
 \text{Inre resistans}\ R_i = \dfrac{\Delta U_a}{\Delta I_a}
-\end{align*}
+\end{equation*}
 &
 \begin{equation*}
 \begin{aligned}
 R_i\ [k \ohm]\\ \Delta U_a\ [V]\\ \Delta I_a\ [mA]
 \end{aligned}
-\end{equation*}
+\end{equation*}\\
 \end{tabularx}
 %%
 \mediumfig{images/cropped_pdfs/bild_2_2-34.pdf}{Inre resistans}{fig:BildII2-34}


### PR DESCRIPTION
## Innehåll

Denna åtgärdar att två ekvationer i 2.7 stoppade genereringen av EPUB. Det kan ha varit att `align*` inte funkar om den bara har en rad att _aligna_.

Detta stänger inget ärende men är ett steg på vägen mot #55 

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [x] Bygger utan fel på byggserver
- [x] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare
