### PR TITLE
Flytta Morsesignalering till bilaga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ och följer [semantisk versionshantering](https://semver.org/lang/sv/spec/v2.0.0
 - Nya delavsnittsnivåer i 1.9 Effekt och energi.
 - Nya delavsnittsnivåer i 13.4 Internationell nödtrafik.
 - Ett räkneexempel om frekvens i 1.6 gjort tydligare.
+- Flyttat Morsesignalering till en bilaga.
 
 ### Fixat
 - Ordet _mod_ har lagts till i sakregistret.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ KONCEPT_CH13_FILES = koncept/chapter13-1.tex koncept/chapter13-2.tex \
 KONCEPT_CH14_FILES = koncept/chapter14-1.tex koncept/chapter14-2.tex \
 	koncept/chapter14-3.tex
 KONCEPT_CH15_FILES = koncept/chapter15-1.tex
-KONCEPT_CH16_FILES = koncept/chapter16-1.tex
 KONCEPT_APDX_FILES = koncept/appendix-bandplaner.tex koncept/appendix-beskrivningskoder.tex \
 	koncept/appendix-decibel.tex koncept/appendix-frekvensplan.tex \
 	koncept/appendix-iaru-bandplan.tex koncept/appendix-iaru-bandplan2.tex  \
@@ -63,7 +62,7 @@ KONCEPT_APDX_FILES = koncept/appendix-bandplaner.tex koncept/appendix-beskrivnin
 	koncept/appendix-litteratur.tex koncept/appendix-matematik.tex \
 	koncept/appendix-mattenheter.tex koncept/appendix-prefixomvandling.tex \
 	koncept/appendix-rapportkoder.tex koncept/appendix-repeatrar.tex \
-	koncept/appendix-s-enheter.tex
+	koncept/appendix-s-enheter.tex koncept/appendix-morsesignalering.tex
 KONCEPT_OTHER_FILES = koncept/foreword.tex koncept/introduction.tex \
 	koncept/frontpage.tex koncept/tryckort.tex koncept/backpage.tex \
 	koncept/matte.tex koncept.bib \
@@ -76,7 +75,7 @@ KONCEPT_FILES = $(KONCEPT_CH01_FILES) $(KONCEPT_CH02_FILES) \
 	$(KONCEPT_CH09_FILES) $(KONCEPT_CH10_FILES) \
 	$(KONCEPT_CH11_FILES) $(KONCEPT_CH12_FILES) \
 	$(KONCEPT_CH13_FILES) $(KONCEPT_CH14_FILES) \
-	$(KONCEPT_CH15_FILES) $(KONCEPT_CH16_FILES) \
+	$(KONCEPT_CH15_FILES) \
 	$(KONCEPT_APDX_FILES) $(KONCEPT_OTHER_FILES)
 
 REPO_FILES = SHA.tmp branch.tmp

--- a/koncept/appendix-morsesignalering.tex
+++ b/koncept/appendix-morsesignalering.tex
@@ -55,7 +55,9 @@ Mellan hela tecknen inom ord eller teckengrupp ska mellanrummet vara
 tre enheter långt och mellan hela ord eller teckengrupper sju enheter långt.
 Morsetecknen finns standardiserade i ITU-R M.1677-1 \cite{M1677-1}.
 
-\section{Planlagd övning}
+\section{Övning}
+
+\subsection{Planlagd övning}
 
 Att delta i en organiserad kurs i den lokala radioklubben, FRO-avdelningen etc.
 är bra, eftersom man då kan få en handledare och tillgång till övningsmaterial.
@@ -71,7 +73,7 @@ Det går att hoppa över 1--2 dagar i veckan, men det bör då ingå i övningsp
 Att hoppa över ännu fler blir lätt en ovana.
 Att träna lite då och då ger inget bra resultat.
 
-\section[Inlärningsordning]{Ordning för teckeninlärning}
+\subsection[Inlärningsordning]{Ordning för teckeninlärning}
 
 \begin{table}[ht]
   \centering
@@ -117,7 +119,7 @@ Följ kursens ordning och hoppa inte över något!
 Öva utan avbrott så att hjärnan blir ordentligt ''programmerad''.
 Det är lämpligt att lära in 2 till 4 nya tecken varje vecka.
 
-\section{Inlärningstid}
+\subsection{Inlärningstid}
 
 Behövlig inlärningstid är mycket individuell.
 För 40~tecken/minut, som motsvarade ett C-certifikat en gång i tiden, bör man
@@ -127,7 +129,7 @@ sändning.
 Att klara en taktökning till 60~tecken/minut och högre krav på säkerhet i både
 mottagning och sändning, bör man räkna med ytterligare 25~timmar eller mer.
 
-\section{Inlärningsmetodik}
+\subsection{Inlärningsmetodik}
 
 Morsetelegrafi bör läras med beprövad metodik.
 Bästa sättet är att man också skriver ner tecknen när man hör dem.
@@ -137,7 +139,7 @@ Att träna bara genom att höra tecknen är nästan verkningslöst.
 Först när du lärt dej alla morsetecken grundligt genom mottagning är det dags
 med sändningsträning.
 
-\section{Mottagnings\-övningar}
+\subsection{Mottagnings\-övningar}
 
 Morsetecken är ju långa och korta teckendelar i form av ljud, ljus etc.
 De kan även illustreras som långa och korta streck.
@@ -187,7 +189,7 @@ Inlärningstexter är ofta uppdelade i grupper med 5 eller 4 tecken.
 Dessa ska simulera ord.
 Var noga med att du får tydliga ordmellanrum även på papperet.
 
-\section[Eftersläpning]{Eftersläpning vid mottagning}
+\subsection[Eftersläpning]{Eftersläpning vid mottagning}
 
 Tiden för vart och ett morsetecken varierar kraftigt.
 För att få en lugnare nedskrivning bör man försöka hålla några tecken i minnet
@@ -203,7 +205,7 @@ Man tappar lätt den text som man just då tar emot.
 Läs alltså inte och gissa inte på orden.
 Täck över det skrivna med den lediga handen!
 
-\section{Sändningsövningar}
+\subsection{Sändningsövningar}
 
 Att telegrafera är att uttrycka sig.
 De handsända morsetecknen ska vara tydliga, på samma sätt som att tal och
@@ -213,7 +215,7 @@ Speciellt de första sändningsövningarna bör ske tillsammans med en kunnig
 instruktör.
 Om instruktör saknas -- följ då noga anvisningarna och var självkritisk!
 
-\section[Övningshjälpmedel]{Hjälpmedel vid sändningsövning}
+\subsection[Övningshjälpmedel]{Hjälpmedel vid sändningsövning}
 
 För sändningsövningarna behövs en dator med ljudfiler eller träningsprogram.
 Vidare behövs en summer ansluten till en telegrafnyckel och en stereohörtelefon.
@@ -228,7 +230,7 @@ paddel'' därför kommer ett fel sällan ensamt.
 
 \multifig{images/cropped_pdfs/bild_morse_3.pdf,images/cropped_pdfs/bild_morse_4.pdf}{Rätt sittställning sett framifrån och från sidan}{fig:bild_morse_3_4}
 
-\section[Ställning]{Arbetsställning vid sändning}
+\subsection[Ställning]{Arbetsställning vid sändning}
 
 Det är viktigt att ha rätt arbetsställning redan från början.
 Vid hög sändningstakt och långa sändningspass blir man annars lätt trött och
@@ -250,7 +252,7 @@ Nyckeln bör vara fastsatt.
 Det är tyvärr vanligt, att nyckeln ställs löst på ett olämpligt högt bord.
 Detta medför en olämplig och tröttande arbetsställning.
 
-\section[Fattning]{Nyckelfattning och handrörelser}
+\subsection[Fattning]{Nyckelfattning och handrörelser}
 
 \smallfig{images/cropped_pdfs/bild_morse_5.pdf}{Rätta handledsrörelser}{fig:bild_morse_5}
 
@@ -269,7 +271,7 @@ I det vågräta läget når nyckeln sitt så kallade kontaktläge.
 För att nästa tecken ska hinnas med i tid, får handleden inte svänga djupare än
 till det vågräta läget.
 
-\section{Styrd sändning}
+\subsection{Styrd sändning}
 
 Sändningsövningarna börjar med styrd sändning, men först sedan morsetecknen
 lärts in grundligt genom lyssning.
@@ -298,7 +300,7 @@ Träna mycket på siffror i den styrda sändningen.
 Det ger färdighet vid övergångarna mellan korta och långa teckendelar i tecknen.
 Även övergångarna mellan vissa morsetecken kan vara svåra.
 
-\section{Fri sändning}
+\subsection{Fri sändning}
 
 Först ska styrd sändning av ramsor och tecken klaras utan problem.
 Börja först därefter med fri sändning utan ljudförebild.
@@ -318,7 +320,8 @@ Sändningen är ditt visitkort och därför krävs att den har kvalitet.
 
 \section[Teckengivning]{Kontroll av teckengivningen}
 
-Läsbarheten av den sändningsstil, som uppvisas vid certifikatsprovet, bedöms.
+Vid ett prov i morsetelegrafering bedöms läsbarheten av den sändningsstil som
+uppvisas.
 Ett i övrigt godkänt prov kan alltså bli underkänt på grund av dålig
 teckengivning.
 Återkalla därför ett tveksamt utformat morsetecken och sänd om det, men var då

--- a/koncept/inkludera-appendix.tex
+++ b/koncept/inkludera-appendix.tex
@@ -1,42 +1,46 @@
 % Appendix A
-\input{koncept/appendix-mattenheter}
+\input{koncept/appendix-morsesignalering}
 %
 % Appendix B
-\input{koncept/appendix-matematik}
+\input{koncept/appendix-mattenheter}
 %
 % Appendix C
-\input{koncept/appendix-decibel}
+\input{koncept/appendix-matematik}
 %
 % Appendix D
-\input{koncept/appendix-s-enheter}
+\input{koncept/appendix-decibel}
 %
 % Appendix E
-\input{koncept/appendix-beskrivningskoder}
+\input{koncept/appendix-s-enheter}
 %
 % Appendix F
+\input{koncept/appendix-beskrivningskoder}
+%
+% Appendix G
 \input{koncept/appendix-iaru-bandplan}
 \input{koncept/appendix-iaru-bandplan2}
 %
-% Appendix G
+% Appendix H
 \input{koncept/appendix-frekvensplan}
 %
-% Appendix H
+% Appendix I
 \input{koncept/appendix-repeatrar}
 %
-% Appendix I
+% Appendix J
 \input{koncept/appendix-rapportkoder}
 %
-% Appendix J
+% Appendix K
 \input{koncept/appendix-kunskapskrav}
 %
-% Appendix K
+% Appendix L
 \input{koncept/appendix-litteratur}
 %
-% Appendix L
+% Appendix M
 \input{koncept/appendix-prefixomvandling}
 %
-% Appendix M
+% Appendix N
 \input{koncept/appendix-lashanvisningar}
 %
-% Appendix N
+% Appendix O
 \input{koncept/appendix-bandplaner}
+%

--- a/koncept/inkludera-kapitel.tex
+++ b/koncept/inkludera-kapitel.tex
@@ -213,6 +213,3 @@
 \input{koncept/chapter15-1}
 %
 %
-% Kapitel 16 Morsesignalering
-% Avsnitt 16.1--16.18
-\input{koncept/chapter16-1}


### PR DESCRIPTION
## Innehåll

- Flytta Morsesignalering till bilaga för att tydliggöra att den inte är del av det de obligatoriska kunskaperna för certifikatprovet. Fix #686 

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [x] Bygger utan fel på byggserver
- [x] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare
