### PR TITLE
Inga dubbelparentes vid engelska förkortningar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ och följer [semantisk versionshantering](https://semver.org/lang/sv/spec/v2.0.0
 - Ett räkneexempel om frekvens i 1.6 gjort tydligare.
 - Flyttat Morsesignalering till en bilaga.
 - Flytta in bilaga Prefixomvandlingstabell i bilaga Måttenheter.
+- Nytt format för engelska förkortningar så dubbelparentes och kursiverade parenteser undviks.
 
 ### Fixat
 - Ordet _mod_ har lagts till i sakregistret.

--- a/koncept/chapter1-10.tex
+++ b/koncept/chapter1-10.tex
@@ -9,7 +9,7 @@
 \index{FPGA}
 \label{digital_signalbehandling}
 
-\emph{Digital signalbehandling} (eng. \emph{Digital Signal Processing (DSP)})
+\emph{Digital signalbehandling} (eng. \emph{Digital Signal Processing, DSP})
 har blivit allt viktigare i vardagen och så även inom amatörradion i och med
 att \emph{Software Defined Radio (SDR)} blivit en viktig del i allt fler
 radior, liksom användning av vanliga datorer.
@@ -161,7 +161,7 @@ multiplikation av signal och filter för varje frekvens:
 \[Y(f) = X(f)H(f)\]
 %%
 Bägge representerar faltning, och är viktiga för förståelsen av \emph{linjära
-tidsinvarianta} filter (eng. \emph{linear time-invariant (LTI)}) filter,
+tidsinvarianta} filter (eng. \emph{linear time-invariant, LTI}) filter,
 som är det vi i allmänhet fokuserar på.
 
 \subsection{Antivikningsfilter}
@@ -239,8 +239,8 @@ inte vika bandet.
 \label{ADC-DAC}
 
 För att hantera dessa delar använder man analog-till-digital-omvandlare
-(eng. \emph{Analog-Digital Conversion (ADC)}) samt digital-till-analog-omvandlare 
-(eng. \emph{Digital-Analog Conversion (DAC)}).
+(eng. \emph{Analog-Digital Conversion, ADC}) samt digital-till-analog-omvandlare 
+(eng. \emph{Digital-Analog Conversion, DAC}).
 En ADC tar hand om sampling, kvantisering och PCM-kodning medan en DAC
 omvandlar PCM-koden till analog spänning.
 Ofta behöver man komplettera med analoga filter, men moderna sigma-delta-omvandlare 

--- a/koncept/chapter1-8.tex
+++ b/koncept/chapter1-8.tex
@@ -790,7 +790,7 @@ QAM vilka presenteras i följande delavsnitt.
 \index{JT65}
 \index{JT9}
 
-\emph{Frekvensskiftsmodulation} (eng. \emph{Frequency Shift Keying (FSK)})
+\emph{Frekvensskiftsmodulation} (eng. \emph{Frequency Shift Keying, FSK})
 skiljer sig från CW-modulationen genom att den ändrar frekvensen, dvs. är en
 variant av frekvensmodulation. I den enklaste formen, binär FSK växlar man
 mellan två frekvenser, där en frekvens får representera 0 och den andra får
@@ -848,14 +848,14 @@ teckenändringarna på signalen.
 
 Fasskiftmodulation kan även göras med flera nivåer. När fyra olika faslägen
 används kallas det för \emph{fyrnivå fasskiftmodulation} (eng.
-\emph{4-state Phase Shift Keying (4-PSK)}).
+\emph{4-state Phase Shift Keying, 4-PSK}).
 
 Istället för 180~graders fasskift (0 och 180 grader) som används vid 2-PSK/BPSK
 så använder man 360/4 det vill säga 90 graders fasskift mellan symbolerna.
 Ett effektivt sätt att avkoda det är att göra \emph{kvadraturmodulering}
 (eng. \emph{quadrature modulation}) där man modulerar en signal till två
-komponenter, i \emph{fas} (eng. \emph{In Phase (I)}) och förskjuten 90 grader \emph{kvadratur} (eng.
-\emph{Quadrature (Q)}), ofta kallat I/Q modulering.
+komponenter, i \emph{fas} (eng. \emph{In Phase, I}) och förskjuten 90 grader \emph{kvadratur} (eng.
+\emph{Quadrature, Q}), ofta kallat I/Q modulering.
 
 De fyra faslägena kan nu enkelt förklaras som amplituder i de olika faslägena
 som anges av tabell~\ssaref{tab:4-PSK}.
@@ -899,7 +899,7 @@ En smidigare modulationsform är istället att låta även amplituden variera,
 och genom att låta några bitar modulera I och några bitar modulera Q kan
 man enkelt få ett symbolmönster som är effektivt att implementera.
 Denna modulationsform kallar man \emph{kvadratur-amplitudmodulation}
-(eng. \emph{Quadrature Amplitude Modulation (QAM)}).
+(eng. \emph{Quadrature Amplitude Modulation, QAM}).
 
 Ofta benämner man olika varianter med antalet olika positioner, så att 16QAM
 har 16 olika lägen i fas och amplitud tillsammans.
@@ -975,7 +975,7 @@ modulation.
 \index{informationsöverföringskapacitet}
 \index{bit rate}
 
-Informationen som vi skickar har vi kodat i bitar (eng. \emph{bit (b)}),
+Informationen som vi skickar har vi kodat i bitar (eng. \emph{bit, b}),
 \emph{informationsmängden} vi har är därför ett visst antal bitar och takten på
 denna informationsmängd blir därmed \emph{informationsöverföringskapaciteten}
 (eng. \emph{bit rate}) i bitar per sekund.
@@ -1101,17 +1101,19 @@ fel, och det kan då leda till 1 eller fler bitfel.
 
 Om vi antar att vi inte har störning från några andra signaler, utan enbart har
 brus som störning, så kan vi estimera \emph{bitfelssannolikheten} (eng.
-\emph{bit error rate (BER)}) ur hur starkt bruset är i förhållande till vårt
-steg. Eftersom bruset antas vara vitt brus, så har det egenskaperna av
-\emph{Gaussiskt brus} (eng. \emph{Gaussian noise}).
+\emph{bit error rate, BER}) ur hur starkt bruset är i förhållande till vårt
+steg.
+Eftersom bruset antas vara vitt brus, så har det egenskaperna av \emph{Gaussiskt
+brus} (eng. \emph{Gaussian noise}).
 
 Gaussiskt brus har en statistisk fördelning med hög sannolikhet nära
-medelvärdet och avtar sedan med avståndet. Sannolikheten att man tolkar en
-signal som vara på ena eller andra sidan av en gräns beror på hur långt bort
-från medelvärdet den gränsen, ofta benämnd kvantiseringsgränsen, är i
-förhållande till den effektiva värdet (eng. \emph{Root Mean Square (RMS)}) i
-amplitud hos bruset. Detta kan uttryckas i form av den matematiska funktionen
-\emph{error function (erf)}.
+medelvärdet och avtar sedan med avståndet.
+Sannolikheten att man tolkar en signal som vara på ena eller andra sidan av en
+gräns beror på hur långt bort från medelvärdet den gränsen, ofta benämnd
+kvantiseringsgränsen, är i förhållande till den effektiva värdet (eng.
+\emph{Root Mean Square, RMS}) i amplitud hos bruset.
+Detta kan uttryckas i form av den matematiska funktionen \emph{error function
+(erf)}.
 
 När gränsen är 1~sigma, det vill säga 1 gånger RMS-värdet för brusamplituden,
 från medelvärdet så är det 67~\% sannolikhet att värdet ligger inom
@@ -1167,7 +1169,7 @@ tagit emot har fel, är att begära omsändning.
 Genom att sändaren håller en buffert med meddelanden som den skickat, och
 mottagaren meddelar sändare om den mottagit meddelandet eller behöver ha det
 omskickat, så kan omsändning realiseras.
-Automatisk omsändningsbegäran (eng. \emph{Automatic Repeat reQuest (ARQ)}) är en
+Automatisk omsändningsbegäran (eng. \emph{Automatic Repeat reQuest, ARQ}) är en
 typ av protokoll som gör automatisk omsändningsbegäran om ett enskilt datablock,
 även kallat paket, inte kommit fram rätt eller helt försvunnit.
 Ett sådant protokoll är TCP, som ingår i internetsviten av TCP/IP-protokollet.

--- a/koncept/chapter11-1.tex
+++ b/koncept/chapter11-1.tex
@@ -7,7 +7,7 @@
 En amatörradiostation skickar ut radiovågor, signaler, för att kommunicera
 trådlöst med hela världen.
 Radiovågorna kallas även elektromagnetiska fält (EMF)
-(eng. \emph{Electromagnetic Field (EMF)}).
+(eng. \emph{Electromagnetic Field, EMF}).
 Runt alla antenner som sänder ut radiovågor bildas elektromagnetiska fält av den
 energi som skickas in i antennerna från radiosändaren.
 

--- a/koncept/chapter2-5.tex
+++ b/koncept/chapter2-5.tex
@@ -147,7 +147,7 @@ varianter.
 \index{diod!laserdiod}
 \label{diod_led}
 
-\emph{Lysdiod} (eng. \emph{Light Emitting Diode (LED)}) är en diod anpassad för
+\emph{Lysdiod} (eng. \emph{Light Emitting Diode, LED}) är en diod anpassad för
 att leverera ljus, ofta synligt sådant.
 Lysdioder finns tillgängliga med infrarött, rött, orange, gult, grönt,
 blått och vitt ljus.

--- a/koncept/chapter3-10.tex
+++ b/koncept/chapter3-10.tex
@@ -9,7 +9,7 @@ blivit allt vanligare med olika former av digital signalbehandling, och dessa
 används i varierande grad även i radiodesign.
 
 Ofta sammanfattas det med termen \emph{digital signalbehandling} (eng.
-\emph{Digital Signal Processing (DSP)}).
+\emph{Digital Signal Processing, DSP}).
 
 Ofta förväxlas det begreppet med Digital Signal Processor (DSP), som kommit att
 representera en typ av processorer anpassade för signalbearbetning.
@@ -90,7 +90,7 @@ signalstyrka över frekvens.
 Eftersom processingen sker i diskret tid, det vill säga värden med en viss tid
 emellan, så som ofrånkomligt med samplade värden, så är det ett specialfall av
 fouriertransform, som därför heter \emph{diskret fouriertransform} (eng.
-\emph{Discrete Fourier Transform (DFT)}).
+\emph{Discrete Fourier Transform, DFT}).
 
 DFT kan göras på alla möjliga längder av sekvenser, men är beräkningstungt
 om man vill ha alla möjliga frekvenser.
@@ -136,7 +136,7 @@ oscillator direkt syntetisera en vågform, och man kan göra det med väldigt
 hög upplösning och ändra den väldigt fort.
 Medan det kan göras på många sätt, så är den dominerande principen den att
 man gör en oscillator med en så kallad \emph{fasackumulator} (eng. \emph{phase
-accumulator (PA)}).
+accumulator, PA}).
 En fasackumulator är inget annat än ett adderingssteg följt av en delay-steg.
 Det är ett extremfall av ett IIR filter, med enbart en pol, som integrerar,
 det vill säga ackumulerande effekt.

--- a/koncept/chapter3-2.tex
+++ b/koncept/chapter3-2.tex
@@ -41,7 +41,7 @@ Vi beskriver här först några olika typer av klassiska analoga filter.
 \mediumtopfig{images/cropped_pdfs/bild_2_3-22.pdf}{Högpassfilter}{fig:BildII3-22}
 
 
-Ett \emph{högpassfilter} (eng. \emph{highpass filter (HP)},
+Ett \emph{högpassfilter} (eng. \emph{highpass filter, HP}),
 bild~\ssaref{fig:BildII3-22}) släpper igenom signaler med höga frekvenser och
 dämpar de med låga frekvenser.
 
@@ -104,7 +104,7 @@ Om induktor och kondensator respektive resistor och kondensator i ett
 högpassfilter byter plats, som i bild~\ssaref{fig:BildII3-23}, så får man i
 stället ett LC-lågpassfilter respektive ett RC-lågpassfilter.
 
-Ett \emph{lågpassfilter} (eng. \emph{lowpass filter (LP)}) släpper igenom
+Ett \emph{lågpassfilter} (eng. \emph{lowpass filter, LP}) släpper igenom
 signaler med låga frekvenser och dämpar de med höga frekvenser.
 
 \paragraph{Exempel} En frekvensberoende spänningsdelare som LC-lågpassfilter.

--- a/koncept/chapter3-7.tex
+++ b/koncept/chapter3-7.tex
@@ -20,7 +20,7 @@ Kvartskristallens höga Q-värde ger också en renare signal.
 
 \tallfig{images/cropped_pdfs/bild_2_3-75.pdf}{Colpittsoscillator med kristall i parallellresonansfallet}{fig:BildII3-75}
 
-I en \emph{kristalloscillator} (eng. \emph{Crystal Oscillator (XO)}) är en
+I en \emph{kristalloscillator} (eng. \emph{Crystal Oscillator, XO}) är en
 kvartskristall det frekvensbestämmande elementet i stället för en LC-krets.
 I övrigt kan samma kopplingsprinciper som för en LC-VFO användas.
 
@@ -146,7 +146,7 @@ En LC-oscillator arbetar däremot inom ett frekvensområde (VFO), som bestäms a
 en LC-krets.
 Dennas frekvens är emellertid mindre stabil än den med styrkristall.
 
-I en \emph{faslåst loop} (eng. \emph{Phase Locked Loop (PLL)}) kan god
+I en \emph{faslåst loop} (eng. \emph{Phase Locked Loop, PLL}) kan god
 frekvenstabilitet och stort frekvensområde förenas.
 En PLL är en sluten krets för elektrisk styrning av en oscillator, så att dess
 frekvens är både stabil och variabel.
@@ -163,9 +163,8 @@ frekvens är både stabil och variabel.
 \index{varicap}
 
 I bild~\ssaref{fig:BildII3-78} jämförs en VFO och en VCO.
-En VFO, vars frekvens kan styras med en likspänning, kallas
-\emph{spänningstyrd oscillator} (eng. \emph{Voltage Controlled Oscillator
-  (VCO)}).
+En VFO, vars frekvens kan styras med en likspänning, kallas \emph{spänningstyrd
+oscillator} (eng. \emph{Voltage Controlled Oscillator, VCO}).
 I resonanskretsen i en VCO fyller en kapacitansdiod (eng. \emph{varicap, variable
 capacitor}) samma uppgift som den mekaniskt variabla kondensatorn i en VFO.
 

--- a/koncept/chapter4-1.tex
+++ b/koncept/chapter4-1.tex
@@ -51,7 +51,7 @@ Man kan till exempel vilja ha god isolation vid sändar- och mottagarfrekvensen
 \emph{Jordning} (eng. \emph{bonding}) eller dagligt tal \emph{jord} (eng.
 \emph{ground}, \emph{earth}) är en kopplingsstrategi för att få samma
 referenspotential i olika delar av en elektrisk koppling.
-Man bygger ett \emph{jordnät} (eng. \emph{bonding network (BN)}
+Man bygger ett \emph{jordnät} (eng. \emph{bonding network, BN})
 \cite[kap 3.2.1]{K27-1991} och \emph{earthing network})
 \cite[kap 3.1.3]{K27-1991} för att koppla samman de olika jordpunkterna.
 
@@ -303,7 +303,7 @@ Det finns givetvis många vägar för brum att störa en signal.
 En strategi för att skapa isolation från jordvägen är att helt enkelt
 isolera signalerna och deras jord från kraftförsörjningens jord, detta kallas
 för \emph{isolerad jordning} (eng. \emph{isolated bonding} även \emph{isolated
- bonding network (IBN)}) \cite[kap 3.2.4]{K27-1991}.
+ bonding network, IBN}) \cite[kap 3.2.4]{K27-1991}.
 Man börjar plötsligt prata om \emph{skyddsjord} skilt från \emph{signaljord}
 (eng. \emph{signal ground}).
 
@@ -431,7 +431,7 @@ elsäkerhet, vilket indikerar att man valt en felaktig lösning.
 \index{skyddsjord}
 
 En annan strategi är \emph{sammankopplad jordning} (eng. \emph{mesh bonding}
-och \emph{mesh bonding network (mesh-BN)}) \cite[kap 3.2.3]{K27-1991}
+och \emph{mesh bonding network, mesh-BN}) \cite[kap 3.2.3]{K27-1991}
 där man istället för att isolera satsar på att koppla samman jordarna, hårt.
 Varje signalkabel sitter ansluten mot \emph{chassijord} och därmed
 \emph{skyddsjord} och man låter därmed jordarna sammankopplas.
@@ -570,7 +570,7 @@ Den balanserade signalen har jord, \emph{pluspol} och \emph{minuspol}.
 \emph{minuspolen} kallas även -, \emph{negativ polaritet}, \emph{kall} (eng.
 \emph{negative pole}, \emph{negative polarity} och \emph{cold}).
 Utöver dessa har man oftast en \emph{spänningsreferens} som ofta betäcknas som
-\emph{jord} (eng. \emph{ground (GND)}) eller \emph{nolla} (eng.
+\emph{jord} (eng. \emph{ground, GND}) eller \emph{nolla} (eng.
 \emph{neutral}).
 
 I bild~\ssaref{fig:kap4-6} visas hur ut-spänningen \(U_{ut}\) är dubblerad och
@@ -768,8 +768,8 @@ Efter att ha studerat gemensam och differentiell spänning (kapitel
 \ssaref{comdiffv}) och gemensam och differentiell ström (kapitel~\ssaref{comdiffi})
 kan vi sammanfattningsvis konstatera att den grundläggande metoden att omvandla
 de individuella spänningarna och strömmarna till \emph{gemensam överföring}
-(eng. \emph{Common Mode (CM)}) och \emph{differentiell överföring}
-(eng. \emph{Differential Mode (DM)}) är en kraftfull metod både för att
+(eng. \emph{Common Mode, CM}) och \emph{differentiell överföring}
+(eng. \emph{Differential Mode, DM}) är en kraftfull metod både för att
 förstå och avhjälpa problem och uppnå isolation.
 För spänning har vi ekvationerna
 %%

--- a/koncept/chapter5-8.tex
+++ b/koncept/chapter5-8.tex
@@ -21,7 +21,7 @@ Det är därför nödvändigt att minska förstärkningen även i HF- och
 MF-förstärkarstegen, ju mer desto starkare insignalen är.
 Som hjälpmedel finns oftast ett reglage för HF-förstärkningen (RF gain), och
 därutöver en \emph{automatisk förstärkningsreglering} (eng. \emph{Automatic
-Gain Control (AGC)}).
+Gain Control, AGC}).
 
 En mottagare med god reglering kan arbeta med signalstyrkor mellan mikrovolt
 och volt.

--- a/koncept/chapter6-1.tex
+++ b/koncept/chapter6-1.tex
@@ -196,7 +196,7 @@ säga en utsignal ska vara proportionell mot insignalen i varje moment.
 PLL-styrning är inte ett sändarkoncept.
 Det är ett sätt att styra frekvensen i en oscillator och hålla den stabil med
 hjälp av en likspänning från en \emph{faslåst loop} (eng.
-\emph{Phase Locked Loop (PLL)}) vilket är en digitalt styrd krets.
+\emph{Phase Locked Loop, PLL}) vilket är en digitalt styrd krets.
 
 En PLL kan användas till exempel i raka sändare och heterodynsändare.
 I det första fallet (bild~\ssaref{fig:bildII5-2}) kan frekvensen i den enda
@@ -397,8 +397,8 @@ sidband i så kallat splatter eller tar upp spegelfrekvenser.
 
 När man sänder skapas \emph{sidband} (eng. \emph{side band}).
 För AM och SSB så skapas bägge, \emph{övre sidbandet}
-(eng. \emph{Upper Side Band (USB)}) eller \emph{undre sidbandet}
-(eng. \emph{Lower Side Band (LSB)}) av den modulerade signalen.
+(eng. \emph{Upper Side Band, USB}) eller \emph{undre sidbandet}
+(eng. \emph{Lower Side Band, LSB}) av den modulerade signalen.
 För SSB undertrycks även bärvågen.
 För FM skapas bredare sidband som behöver filtreras.
 

--- a/koncept/chapter6-2.tex
+++ b/koncept/chapter6-2.tex
@@ -262,7 +262,7 @@ det hörs en svävningston när en bärvåg tas emot.
 Utan denna frekvensändring skulle endast bärvågsbruset höras.
 
 Även en RIT och en \emph{talstyrd sändning} (eng.
-\emph{Voice Operated Xmitter (VOX)}) är inritade.
+\emph{Voice Operated Xmitter, VOX}) är inritade.
 
 
 \newpage

--- a/koncept/chapter8-3.tex
+++ b/koncept/chapter8-3.tex
@@ -184,7 +184,7 @@ Radiovågorna vandrar från sändaren till en avlägsen mottagare genom att
 reflekteras en eller flera gånger i jonosfären och på jordytan.
 Se bild~\ssaref{fig:bildII7-8}.
 För att detta ska ske kan frekvensen inte vara högre än den
-\emph{högsta användbara frekvensen} (eng. \emph{Maximum Usable Frequency (MUF)})
+\emph{högsta användbara frekvensen} (eng. \emph{Maximum Usable Frequency, MUF})
 för en viss överföringssträcka.
 
 MUF är högst mitt på dagen eller tidig eftermiddag.
@@ -221,7 +221,7 @@ FOT är vanligen ungefär \qty{15}{\percent} lägre än MUF.
 Ju lägre sändningsfrekvens som väljs, desto mer dämpas vågorna i
 jonosfären, intill den frekvens då de inte kan uppfattas.
 Den \emph{lägsta användbara frekvensen}
-(eng. \emph{Lowest Usable Frequency (LUF)}) är den
+(eng. \emph{Lowest Usable Frequency, LUF}) är den
 frekvens som ger tillfredsställande kommunikation för en viss
 utbredningsväg och vid en viss tidpunkt.
 

--- a/koncept/chapter8-7.tex
+++ b/koncept/chapter8-7.tex
@@ -80,7 +80,7 @@ bruset att dominera, och dämpningar i kablar bli allt mer märkbart.
 Upplevelsen av en signals kvalitet kan mätas på många sätt, dock är just
 signalens brusmängd en viktig sådan relation och därför så använder man
 begreppet \emph{signal-brus-förhållande} (eng.
-\emph{signal to noise ratio (S/N)}).
+\emph{signal to noise ratio, S/N}).
 
 Signal-brus förhållandet uttrycks oftast i \unit{\decibel} och kan enkelt räknas
 fram som skillnaden i nivå på signal och på brus, det vill säga signal minus
@@ -137,10 +137,10 @@ så den ska uppskattas eller mätas för den frekvens som avses.
 För högre frekvenser tenderar brus domineras av mottagarens interna brus,
 samtidigt som kabelförluster börjar bli märkbara.
 För sådana fall kan det vara lämpligt att installera en
-\emph{lågbrusig förstärkare} (eng. \emph{low noise amplifier (LNA)}) före
+\emph{lågbrusig förstärkare} (eng. \emph{low noise amplifier, LNA}) före
 mottagaren.
 Även den förstärkaren har dock egenbrus som sedan förstärks.
-\emph{Brusfaktor} (eng. \emph{noise factor (NF)}) ger förhållandet mellan en
+\emph{Brusfaktor} (eng. \emph{noise factor, NF}) ger förhållandet mellan en
 förstärkares egenbrus i förhållande till det termiska bruset för ett motstånd
 på dess ingång.
 Brusfaktor redovisas oftast i \unit{\decibel}, som varande dB över brusgolvet.

--- a/koncept/chapter9-1.tex
+++ b/koncept/chapter9-1.tex
@@ -301,7 +301,7 @@ reflekteras tillbaka från antennen.
 
 Det uppstår då en stående våg i ledningen. Förhållandet mellan inmatad
 och reflekterad effekt uttrycks som ett \emph{ståendevågförhållande (SVF)}
-(eng. \emph{Standing Wave Ratio (SWR)}).
+(eng. \emph{Standing Wave Ratio, SWR}).
 
 Med en SVF-meter som sätts in mellan effektkälla och ledning kan man
 mäta hur stor effekt som matas in i ledningen och hur stor effekt som

--- a/koncept/chapter9-2.tex
+++ b/koncept/chapter9-2.tex
@@ -182,7 +182,7 @@ avvikande impedans, kommer HF-energi att reflekteras i övergången.
 
 Denna reflekterade energi kan mätas med en \emph{ståendevågmeter}
 (eng. \emph{SWR-meter}) så som illustreras i bild~\ssaref{fig:bildII8-9}.
-Med \emph{ståendevåg-förhållande (SVF)} (eng. \emph{Standing Wave Ratio (SWR)}
+Med \emph{ståendevåg-förhållande (SVF)} (eng. \emph{Standing Wave Ratio, SWR})
 menas förhållandet mellan den effekt som flyter framåt respektive bakåt i en
 transmissionsledning.
 Användningområden för SVF-meter är:
@@ -580,7 +580,7 @@ en antenn.
 Ibland kallas detta även för \emph{antennanalysator} i amatörradiosammanhang.
 
 En nätverksanalysator som enbart kan mäta amplituder kallas ibland för
-\emph{skalär nätverksanalysator} (eng. \emph{Scalar Network Analyzer (SNA)}).
+\emph{skalär nätverksanalysator} (eng. \emph{Scalar Network Analyzer, SNA}).
 En spektrumanalysator med en så kallad \emph{tracking generator}, som genererar
 en signal med samma frekvens som man analyserar, kan agera SNA.
 En signalgenerator med svepfunktion kan också agera SNA.
@@ -589,7 +589,7 @@ En nätverksanalysator som mäter fasen både på utgående och inkommande signa
 kan även mäta fasförskjutningen, och då kan man representera fasen både som
 komplex storhet eller med polära koordinater, det vill säga amplitud och fas.
 En sådan nätverksanalysator kallas för \emph{vektornätverksanalysator} (eng.
-\emph{Vector Network Analyzer (VNA)}).
+\emph{Vector Network Analyzer, VNA}).
 
 Användningsmässigt liknar en nätverksanalysator en spektrum-analysator, men
 med flera väsentliga skillnader.


### PR DESCRIPTION
## Innehåll

- Meddela engelska förkortningar med hjälp av kommatecken istället för dubbelparentes. Fix #524 

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [x] Bygger utan fel på byggserver
- [x] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare