### PR TITLE
Ersatt fyra bilder i kapitel två med hjälp av circuitikz

### DIFF
--- a/koncept/chapter2-5.tex
+++ b/koncept/chapter2-5.tex
@@ -99,16 +99,31 @@ Produkten av spänningsfallet över dioden och strömmen genom den kallas
 förlusteffekt. Denna värmer upp dioden. Vid för hög temperatur förstörs
 kristallstrukturen.
 En kiselkristall kan klara upp till \qty{200}{\degreeCelsius} medan en
-germaniumkristall bara klarar \qty{75}{\degreeCelsius}.
+germaniumkristall bara klarar \qty{75}{\degreeCelsius}.\\
 
-\smallfig[0.25]{images/cropped_pdfs/bild_2_2-14.pdf}{Schemasymboler för dioder}{fig:BildII2-14}
+\smalltikz{
+		\begin{circuitikz}[american voltages]
+	% diodetyper bild 2.16
+	% diod
+	\draw (0,0) to [D-, a_=$1$, l2^=K and A] (0,1);
+	% zenerdiod
+	\draw (1.5,0) to [zD-, l_=$2$] (1.5,1);
+	% kapacitansdiod
+	\draw (3,0) to [VC-, l_=$3$] (3,1);
+	% lysdiod
+	\draw (4.7,0) to [leD-, l_=$4$] (4.7,1);
+\end{circuitikz}
+}{Schemasymboler för dioder}{fig:BildII2-14}
 
 \newpage
 \subsection{Diodtillämpningar}
 \harecsection{\harec{a}{2.5.1.1}{2.5.1.1}}
 
-Bild~\ssaref{fig:BildII2-14} illustrerar flera olika schemasymboler för dioder.
-
+Bild~\ssaref{fig:BildII2-14} illustrerar flera olika schemasymboler för dioder.\\
+1 Diod allmän symbol med Katod och Anod\\
+2 Zenerdiod\\
+3 Kapacitansdiod\\
+4 Lysdiod (LED)\\
 
 % \noindent
 Likriktning är den vanligaste tillämpningen för dioder (se
@@ -175,7 +190,42 @@ Dessa har blivit tillgängliga till lågt pris och populära för experiment.
 \subsection{Vakuumdioden i jämförelse med halvledardioden}
 
 % \smallfig[0.45]{images/cropped_pdfs/bild_2_2-15.pdf}{Dioders polarisering i kretsen}{fig:BildII2-15}
-\mediumfig{images/cropped_pdfs/bild_2_2-15.pdf}{Dioders polarisering i kretsen}{fig:BildII2-15}
+%\mediumfig{images/cropped_pdfs/bild_2_2-15.pdf}{Dioders polarisering i kretsen}{fig:BildII2-15}
+
+\smalltikz{
+\begin{circuitikz}[american voltages]
+	% dioder polarisering bild 2.17
+	% passriktning
+	%vakuumdiode
+	\draw (0,0) node[diodetube]{};
+	\draw (0,1) to (2,1);
+	\draw (2,1) to [R, a^=$R$] (2,-1);
+	\draw (2,-1) to [american voltage source] (-0.3,-1);
+	%diod
+	\draw (6,1) to [D-] (4,1);
+	\draw (4,1) to (4,-1);
+	\draw (6,1) to [R, a^=$R$] (6,-1);
+	\draw (6,-1) to [american voltage source] (4,-1);
+\end{circuitikz}\\
+Passriktning\\
+
+\begin{circuitikz}[american voltages]
+	% dioder polarisering bild 2.17
+	% Spärriktning
+	%vakuumdiod
+	\draw (0,0) node[diodetube]{};
+	\draw (0,1) to (2,1);
+	\draw (2,1) to [R, a^=$R$] (2,-1);
+	\draw (-0.3,-1) to [american voltage source] (2,-1);
+	%diod
+	\draw (6,1) to [D-] (4,1);
+	\draw (4,1) to (4,-1);
+	\draw (6,1) to [R, a^=$R$] (6,-1);
+	\draw (4,-1) to [american voltage source] (6,-1);
+\end{circuitikz}\\
+Spärriktning\\
+
+}{Dioders polarisering i kretsen}{fig:BildII2-15}
 
 Bild~\ssaref{fig:BildII2-15} visar principen för hur de båda diodtyperna ingår i
 en strömkrets.

--- a/koncept/chapter2-5.tex
+++ b/koncept/chapter2-5.tex
@@ -189,9 +189,6 @@ Dessa har blivit tillgängliga till lågt pris och populära för experiment.
 
 \subsection{Vakuumdioden i jämförelse med halvledardioden}
 
-% \smallfig[0.45]{images/cropped_pdfs/bild_2_2-15.pdf}{Dioders polarisering i kretsen}{fig:BildII2-15}
-%\mediumfig{images/cropped_pdfs/bild_2_2-15.pdf}{Dioders polarisering i kretsen}{fig:BildII2-15}
-
 \smalltikz{
 \begin{circuitikz}[american voltages]
 	% dioder polarisering bild 2.17

--- a/koncept/chapter2-6.tex
+++ b/koncept/chapter2-6.tex
@@ -4,7 +4,28 @@
 \label{transistorn}
 \index{transistor}
 
-\smallfig{images/cropped_pdfs/bild_2_2-16.pdf}{Schemasymboler}{fig:BildII2-16}
+%\smallfig{images/cropped_pdfs/bild_2_2-16.pdf}{Schemasymboler}{fig:BildII2-16}
+
+\smalltikz{
+	\begin{circuitikz}[american,]
+	% transistortyper bild 2.18
+	% npn transistor med markerade anslutningar
+	\draw (0,0) node[npn, tr circle=true](npn){NPN};
+	\draw (npn.E) node[below]{E};
+	\draw (npn.C) node[above]{C};
+	\draw (npn.B) node[left]{B};
+	%pnp transistor med markerade anslutningar
+	\draw (3,0) node[pnp, tr circle=true](pnp){PNP};
+	\draw (pnp.C) node[below]{C};
+	\draw (pnp.E) node[above]{E};
+	\draw (pnp.B) node[left]{B};
+	%jfet transistor med markerade anslutningar
+	\draw (6,0) node[njfet, tr circle=true](njfet){FET};
+	\draw (njfet.E) node[below]{S};
+	\draw (njfet.C) node[above]{D};
+	\draw (njfet.G) node[left]{G};
+\end{circuitikz}
+}{Schemasymboler}{fig:BildII2-16}
 
 \subsection{Allmänt}
 \label{transistor_allmänt}
@@ -12,13 +33,13 @@
 En transistor består av skikt av dopade halvledarelement som sammanfogats.
 Vanligt är två N-skikt och ett mellanliggande P-skikt (NPN-transistor) eller två
 P-skikt och ett mellanliggande N-skikt (PNP-transistor).
-Skikten är försedda med anslutningar.
+Skikten är försedda med anslutningar.\\
 
 Bild~\ssaref{fig:BildII2-16} visar schemasymboler för de vanliga tran\-sistor\-typerna 
 NPN-transistorer (bipolära), PNP-\-tran\-sistorer (bipolära) och
 FET-transistorer (fälteffekt-).
 
-\newpage
+%\newpage
 \subsection{NPN-transistorer}
 \harecsection{\harec{a}{2.6.1b}{2.6.1b}}
 \index{NPN-transistor}
@@ -149,7 +170,18 @@ Man säger därför att en FET är spänningsstyrd.
 men dessa typer har en relativt låg ingångsimpedans och därför högre styrström.
 Man säger därför att de är strömstyrda.
 
-\smallfig[0.15]{images/cropped_pdfs/bild_2_2-20.pdf}{Schemasymbol för en FET}{fig:BildII2-20}
+%\smallfig[0.15]{images/cropped_pdfs/bild_2_2-20.pdf}{Schemasymbol för en FET}{fig:BildII2-20}
+
+\smalltikz{
+	\begin{circuitikz}[american,]
+	% transistortyper bild 2.23
+	%jfet transistor med markerade anslutningar
+	\draw (6,0) node[njfet, tr circle=true](njfet){};
+	\draw (njfet.E) node[below]{S};
+	\draw (njfet.C) node[above]{D};
+	\draw (njfet.G) node[left]{G};
+\end{circuitikz}\\
+}{Schemasymbol för en FET}{fig:BildII2-20}
 
 Bild~\ssaref{fig:BildII2-20} anger en schemasymbol för en FET.
 

--- a/koncept/chapter2-6.tex
+++ b/koncept/chapter2-6.tex
@@ -4,10 +4,8 @@
 \label{transistorn}
 \index{transistor}
 
-%\smallfig{images/cropped_pdfs/bild_2_2-16.pdf}{Schemasymboler}{fig:BildII2-16}
-
 \smalltikz{
-	\begin{circuitikz}[american,]
+	\begin{circuitikz}[]
 	% transistortyper bild 2.18
 	% npn transistor med markerade anslutningar
 	\draw (0,0) node[npn, tr circle=true](npn){NPN};
@@ -170,10 +168,9 @@ Man säger därför att en FET är spänningsstyrd.
 men dessa typer har en relativt låg ingångsimpedans och därför högre styrström.
 Man säger därför att de är strömstyrda.
 
-%\smallfig[0.15]{images/cropped_pdfs/bild_2_2-20.pdf}{Schemasymbol för en FET}{fig:BildII2-20}
 
 \smalltikz{
-	\begin{circuitikz}[american,]
+	\begin{circuitikz}[]
 	% transistortyper bild 2.23
 	%jfet transistor med markerade anslutningar
 	\draw (6,0) node[njfet, tr circle=true](njfet){};


### PR DESCRIPTION
bilderna 2.16 2.17 2.18 och 2.23 har ersatts med kodade figurer

## Innehåll

- Förändringar

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [x] Bygger utan fel lokalt
- [x] Bygger utan fel på byggserver
- [ ] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare

## Stänger följande issues

Fixes # `<- följt av issue-nummer`
