### PR TITLE
Flytta litteraturförteckningen till mellan kapitel och bilagor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ och följer [semantisk versionshantering](https://semver.org/lang/sv/spec/v2.0.0
 - Flytta in bilaga Prefixomvandlingstabell i bilaga Måttenheter.
 - Nytt format för engelska förkortningar så dubbelparentes och kursiverade parenteser undviks.
 - Ersatt Ursigram med Vågutbredningsprognoser.
+- Flyttat litteraturförteckningen till mellan kapitel och bilagor.
 
 ### Fixat
 - Ordet _mod_ har lagts till i sakregistret.

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ KONCEPT_APDX_FILES = koncept/appendix-bandplaner.tex koncept/appendix-beskrivnin
 	koncept/appendix-decibel.tex koncept/appendix-frekvensplan.tex \
 	koncept/appendix-iaru-bandplan.tex koncept/appendix-iaru-bandplan2.tex  \
 	koncept/appendix-kunskapskrav.tex koncept/appendix-lashanvisningar.tex \
-	koncept/appendix-litteratur.tex koncept/appendix-matematik.tex \
+	koncept/appendix-matematik.tex \
 	koncept/appendix-mattenheter.tex \
 	koncept/appendix-rapportkoder.tex koncept/appendix-repeatrar.tex \
 	koncept/appendix-s-enheter.tex koncept/appendix-morsesignalering.tex
 KONCEPT_OTHER_FILES = koncept/foreword.tex koncept/introduction.tex \
 	koncept/frontpage.tex koncept/tryckort.tex koncept/backpage.tex \
-	koncept/matte.tex koncept.bib \
+	koncept/matte.tex koncept/litteratur.tex koncept.bib \
 	koncept/inkludera-kapitel.tex koncept/inkludera-appendix.tex \
 	koncept.tex
 KONCEPT_FILES = $(KONCEPT_CH01_FILES) $(KONCEPT_CH02_FILES) \

--- a/koncept.tex
+++ b/koncept.tex
@@ -677,6 +677,10 @@
 %
 % Infoga alla kapitel.
 \input{koncept/inkludera-kapitel}
+%
+% Infoga litteraturförteckningen.
+\input{koncept/litteratur}
+%
 % Här slutar numreringen av kapitel och börjar om med bokstäver för appendix.
 \appendix
 % Infoga alla appendix.

--- a/koncept/inkludera-appendix.tex
+++ b/koncept/inkludera-appendix.tex
@@ -33,11 +33,8 @@
 \input{koncept/appendix-kunskapskrav}
 %
 % Appendix L
-\input{koncept/appendix-litteratur}
-%
-% Appendix M
 \input{koncept/appendix-lashanvisningar}
 %
-% Appendix N
+% Appendix M
 \input{koncept/appendix-bandplaner}
 %

--- a/koncept/litteratur.tex
+++ b/koncept/litteratur.tex
@@ -1,6 +1,7 @@
 \onecolumn
 \chapter*{Litteraturförteckning}
 \label{ch:litteratur}
+\addcontentsline{toc}{chapter}{Litteraturförteckning}
 
 \begin{flushleft}
   \renewcommand{\chapter}[2]{}%

--- a/koncept/litteratur.tex
+++ b/koncept/litteratur.tex
@@ -1,11 +1,11 @@
 \onecolumn
-\chapter{KonCEPT litteraturförteckning}
-\label{konceptlitteratur}
+\chapter*{Litteraturförteckning}
+\label{ch:litteratur}
 
 \begin{flushleft}
   \renewcommand{\chapter}[2]{}%
-\bibliography{koncept.bib}
-\bibliographystyle{plain}
+  \bibliographystyle{plain}
+  \bibliography{koncept.bib}
 \end{flushleft}
 
 \twocolumn


### PR DESCRIPTION
## Innehåll

- Flytta litteraturförteckningen till mellan kapitel och bilagor. Se #645 

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [x] Bygger utan fel på byggserver
- [x] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare