### PR TITLE
inledande text i fyra kapitel

### DIFF
--- a/koncept/chapter1-5.tex
+++ b/koncept/chapter1-5.tex
@@ -85,7 +85,7 @@ Utbredningshastigheten för ljudvågor är \(v = \text{ca } 340\ \text{m/s}\) vi
 \subsection{Elektromagnetiska fält}
 \harecsection{\harec{a}{1.5.2}{1.5.2}}
 \index{elektromagnetiska fält}
-\label{elektromagnetiska_fält}
+\label{elektromagnetiska_faelt}
 
 Tabell~\ssaref{tab:elektromagnetiskt_spektrum} visar elektromagnetiskt spektrum.
 I detta avsnitt görs i huvudsak endast jämförelse mellan ljusvågor och

--- a/koncept/emc.tex
+++ b/koncept/emc.tex
@@ -6,5 +6,5 @@ Det moderna samhället blir alltmer tekniskt avancerat och antalet elektroniska
 apparater i hemmen och på arbetsplatserna ökar kraftigt.
 Den ökande mängden och komplexiteten hos apparaterna kräver därför regler, som
 styr både utförande och användning med rimligt bibehållen säkerhet och funktion.
-Internationella och nationella väl preciserade regler för radio- och
-teletekniskt samexistens är numera helt nödvändiga.
+Internationella och nationella väl preciserade regler för radio och
+teleteknisk samexistens är numera helt nödvändiga.

--- a/koncept/komponenter.tex
+++ b/koncept/komponenter.tex
@@ -1,2 +1,9 @@
 \chapter{Komponenter}
-\label{komponenter}
+\label{ch:komponenter}
+\index{komponenter}
+
+Komponenter är samlingsnamnet för de delar som tillsammans eller var för sig
+bestämmer hur spänning och ström påverkar funktionen i en elektrisk eller
+elektronisk apparat.
+För att kunna förstå de enskilda komponenterna funktion är det oftast nödvändigt
+att studera deras uppbyggnad.

--- a/koncept/kretsar.tex
+++ b/koncept/kretsar.tex
@@ -1,1 +1,9 @@
 \chapter{Kretsar}
+\label{ch:kretsar}
+\index{kretsar}
+
+När flera likadana eller olika komponenter kopplas ihop bildas en elektrisk
+krets.
+Den sammansatta funktion i en krets är beroende på hur de enskilda komponenterna
+påverkar varandra.
+ 

--- a/koncept/saendare.tex
+++ b/koncept/saendare.tex
@@ -1,1 +1,12 @@
 \chapter[Sändare]{Sändare och transceivers}
+\label{ch:saendare}
+\label{ch:transceiver}
+\index{sändare}
+\index{transceiver}
+
+Sändaren har till uppgift att skapa en högfrekvent elektrisk energi som sedan
+skickas till antennen via transmissionsledningen.
+När energin från sändaren når antennen omvandlas den till ett elektromagnetiskt
+fält.
+Hur fältet sprider sig från antennen beskrivs i
+kapitel~\ssaref{ch:vaagutbredning}.

--- a/koncept/trafikreglemente.tex
+++ b/koncept/trafikreglemente.tex
@@ -1,1 +1,11 @@
 \chapter{Trafikreglemente}
+\label{ch:trafikreglemente}
+\index{trafikreglemente}
+
+För att underlätta kommunikation mellan radioamatörer oavsett vilket språk de
+har som modersmål finns det överenskommelser om betydelsen av bestämda uttryck
+och förkortningar.
+Det finns även överenskommelser om hur radiospektrum bör användas för att så
+många som möjligt ska kunna utöva sin hobby utan att störa andra.
+Alla dessa överenskommelser och regler för uppförande bildar tillsammans med
+lagar och radioamatörens hederskod det som vardagligt kallas trafikreglemente.


### PR DESCRIPTION
fixat inledande text i fyra kapitel.
tagit bort åäö från en label.

## Innehåll

- Förändringar

## Checklista

- [ ] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [ ] Bygger utan fel på byggserver
- [ ] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [ ] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare

## Stänger följande issues

Fixes # `<- följt av issue-nummer`
