### PR TITLE
Ta bort primär/sekundär status från frekvensplan m.m.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,4 @@ indent_style = space
 indent_size = 2
 
 [*.md]
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ och följer [semantisk versionshantering](https://semver.org/lang/sv/spec/v2.0.0
 - Bytt ut "vetenskaplig notation" till "grundpotensform".
 - Några bråktal i appendix Matematik får plats utan att påverka radhöjden.
 - Rätt namn på broschyr om elolyckor i litteraturlistan.
+- Primär och sekundär status borttaget från bilaga svensk frekvensplan.
 
 ### Borttaget
 - Text om integrationsgrad borttagen.

--- a/koncept/appendix-frekvensplan.tex
+++ b/koncept/appendix-frekvensplan.tex
@@ -10,8 +10,8 @@ att minska störningarna mellan olika tjänster och länder.
 Överenskommelserna leder fram till en frekvensplan som förutom frekvensband även
 redovisar för vilka tjänster som har primär status och därvid har företräde före
 tjänster med lägre status.
-Observera att flera tjänster kan ha delad primär status i ett band, som till
-exempel i frekvensbanden \SIrange{3500}{3800}{\kilo\hertz} och
+Flera tjänster kan ha delad primär status i ett band, som till exempel i
+frekvensbanden \SIrange{3500}{3800}{\kilo\hertz} och
 \SIrange{432}{438}{\mega\hertz}.
 
 Med stöd av SFS~2022:511 har Post- och telestyrelsen (PTS)
@@ -22,16 +22,16 @@ Notera att PTS med viss regelbundenhet uppdaterar undantagsföreskrifterna,
 och därför bör man kontrollera på PTS webbplats vad som är den senaste versionen
 och använda den när den trätt i kraft.
 
-Bilaga 1 till de allmänna råden utgör den svenska frekvensplanen som reglerar
+Bilaga~1 till de allmänna råden utgör den svenska frekvensplanen som reglerar
 vilka frekvenser som är upplåtna i Sverige samt vilka tjänster som kan nyttja
-frekvenserna och vilka tjänster som har primär respektive sekundär status inom
-frekvensbanden.
-
-\newpage
+frekvenserna.
+Observera att begreppen primär och sekundär status inte används i PTSFS~2019:1.
 
 De allmänna råden och den svenska frekvensplanen omfattar även av
 EU-kommissionen bindande genomförandebeslut gällande effektiv användning av
 radiospektrum och villkor för inom EU harmoniserade frekvensband.
+
+\newpage
 
 Detaljregleringen gällande amatörradio i Sverige som bygger på ovanstående
 överenskommelser, förordningar och föreskrifter sker sedan i PTSFS~2020:5
@@ -47,55 +47,56 @@ tillåtna frekvensband och uteffekter för amatörradio i Sverige.
 Denna föreskrift har naturligtvis företräde över IARU:s bandplaner, vilka
 endast är rekommendationer för hur tilldelade frekvensband bör disponeras.
 
-I tabell~\ssaref{frekvensplan} som bygger på PTSFS 2019:1 och PTSFS 2022:19 visas
-vilka frekvensband som är upplåtna för amatörradio i Sverige, maximal uteffekt
-och om amatörradio har primär eller sekundär status i frekvensbandet.
+I tabell~\ssaref{frekvensplan} som bygger på PTSFS~2019:1 och PTSFS~2022:19
+visas vilka frekvensband som är upplåtna för amatörradio i Sverige och maximal
+uteffekt.
 
-I och med införandet av PTSFS 2020:5 begränsades den maximala uteffekten på
+I och med införandet av PTSFS~2020:5 begränsades den maximala uteffekten på
 frekvensbanden för amatörradio till \qty{200}{\watt} \pep.
 PTS införde samtidigt en möjlighet att för enskilda platser ansöka om tillstånd
 för högre effekt.
 
 Mer information gällande ansökan om tillstånd för högre effekt finns på PTS
-webbplats under rubriken tillstånd för amatörradio.
+webbplats på sidorna om tillstånd för amatörradio.
 
 Observera att det inte går att ansöka om tillstånd för högre effekt på alla
-frekvensband. Detta har markerats i tabellens kolumn Högeffekt där maximal
-effekt på dessa frekvensband är angiven.
+frekvensband.
+Detta har markerats i tabellens kolumn Högeffekt där maximal effekt på dessa
+frekvensband är angiven.
 
 \begin{table*}[b!]
   \centering
 \caption{Frekvensband för amatörradio i Sverige}
 \label{frekvensplan}
-\begin{tabular}{clr|rrl|l}
-Frekvensband &  & band & Effekt & Högeffekt & & Amatörradio\\ \hline
-135,7--137,8 & kHz & 2200~m & 1~W & 1~W & \erp & sekundär\\
-472--479 & kHz & 600~m & 1~W & 1~W & \eirp & sekundär\\
-1810--1850 & kHz & 160~m & 200~W & & \pep & primär\\
-1850--1900 & kHz & 160~m & 10~W & 10~W & \pep & sekundär\\
-1900--1950 & kHz & 160~m & 100~W & 100~W & \pep & sekundär\\
-1950--2000 & kHz & 160~m & 10~W & 10~W & \pep & sekunder\\
-3500--3800 & kHz & 80~m  & 200~W & & \pep & primär\\
-5351,5--5366,5 & kHz & 60~m & 15~W & 15~W & \eirp & sekundär\\
-7000--7200 & kHz & 40~m  & 200~W & & \pep & primär\\
-10100--10150 & kHz & 30~m & 150~W & 150~W & \pep & sekundär\\
-14000--14350 & kHz & 20~m & 200~W & & \pep & primär\\
-18068--18168 & kHz & 17~m & 200~W & & \pep & primär\\
-21000--21450 & kHz & 15~m & 200~W & & \pep & primär\\
-24890--24990 & kHz & 12~m & 200~W & & \pep & primär\\
-28000--29700 & kHz & 10~m & 200~W & & \pep & primär\\
-50000--52000 & kHz & 6~m & 200~W & 200~W & \pep & sekundär\\ \hline
-144--146 & MHz & 2~m & 200~W & & \pep & primär\\
-432--438 & MHz & 70~cm & 200~W & & \pep & primär\\
-1240--1300 & MHz & 23~cm & 200~W & & \pep & sekundär\\
-2400--2450 & MHz & 11~cm & 100~mW & 100~mW & \pep & sekundär\\
-5650--5850 & MHz & 5~cm & 200~W & & \pep & sekundär\\
-10,0--10,5 & GHz & 3~cm & 200~W & & \pep & sekundär\\
-24,00--24,25 & GHz & 11~mm & 200~W & & \pep & pri/sek\\
-47,0--47,2 & GHz & 6~mm & 200~W & & \pep & primär\\
-75,5--81,0 & GHz & 4~mm & 200~W & & \pep & pri/sek\\
-122,25--123,00 & GHz & 2~mm & 200~W & & \pep & sekundär\\
-134--141 & GHz & 2~mm & 200~W & & \pep & pri/sek\\
-241--250 & GHz & 1~mm & 200~W & & \pep & pri/sek\\
+\begin{tabular}{clr|rrl}
+Frekvensband &  & band & Effekt & Högeffekt & \\ \hline
+135,7--137,8 & kHz & 2200~m & 1~W & 1~W & \erp \\
+472--479 & kHz & 600~m & 1~W & 1~W & \eirp \\
+1810--1850 & kHz & 160~m & 200~W & & \pep \\
+1850--1900 & kHz & 160~m & 10~W & 10~W & \pep \\
+1900--1950 & kHz & 160~m & 100~W & 100~W & \pep \\
+1950--2000 & kHz & 160~m & 10~W & 10~W & \pep \\
+3500--3800 & kHz & 80~m  & 200~W & & \pep \\
+5351,5--5366,5 & kHz & 60~m & 15~W & 15~W & \eirp \\
+7000--7200 & kHz & 40~m  & 200~W & & \pep \\
+10100--10150 & kHz & 30~m & 150~W & 150~W & \pep \\
+14000--14350 & kHz & 20~m & 200~W & & \pep \\
+18068--18168 & kHz & 17~m & 200~W & & \pep \\
+21000--21450 & kHz & 15~m & 200~W & & \pep \\
+24890--24990 & kHz & 12~m & 200~W & & \pep \\
+28000--29700 & kHz & 10~m & 200~W & & \pep \\
+50000--52000 & kHz & 6~m & 200~W & 200~W & \pep \\ \hline
+144--146 & MHz & 2~m & 200~W & & \pep \\
+432--438 & MHz & 70~cm & 200~W & & \pep \\
+1240--1300 & MHz & 23~cm & 200~W & & \pep \\
+2400--2450 & MHz & 11~cm & 100~mW & 100~mW & \pep \\
+5650--5850 & MHz & 5~cm & 200~W & & \pep \\
+10,0--10,5 & GHz & 3~cm & 200~W & & \pep \\
+24,00--24,25 & GHz & 11~mm & 200~W & & \pep \\
+47,0--47,2 & GHz & 6~mm & 200~W & & \pep \\
+75,5--81,0 & GHz & 4~mm & 200~W & & \pep \\
+122,25--123,00 & GHz & 2~mm & 200~W & & \pep \\
+134--141 & GHz & 2~mm & 200~W & & \pep \\
+241--250 & GHz & 1~mm & 200~W & & \pep \\
 \end{tabular}
 \end{table*}

--- a/koncept/appendix-frekvensplan.tex
+++ b/koncept/appendix-frekvensplan.tex
@@ -47,7 +47,7 @@ tillåtna frekvensband och uteffekter för amatörradio i Sverige.
 Denna föreskrift har naturligtvis företräde över IARU:s bandplaner, vilka
 endast är rekommendationer för hur tilldelade frekvensband bör disponeras.
 
-I tabell~\ssaref{frekvensplan} som bygger på PTSFS~2019:1 och PTSFS~2022:19
+I tabell~\ssaref{frekvensplan} som bygger på PTSFS 2019:1 och PTSFS 2022:19
 visas vilka frekvensband som är upplåtna för amatörradio i Sverige och maximal
 uteffekt.
 


### PR DESCRIPTION
## Innehåll

- Ta bort primär/sekundär status från frekvensplan m.m. Fix #724 

## Checklista

- [x] Följer stilmallen specificerad i [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
- [ ] Bygger utan fel lokalt
- [x] Bygger utan fel på byggserver
- [x] Signifikanta förändringar införda i [CHANGELOG.md](../CHANGELOG.md)
- [x] Författaren är klar och godkänner sammanfogning
- [ ] Språkligt granskad (stavning och grammatik)
- [ ] Godkänd av två granskare
